### PR TITLE
feat: release 2.2.x

### DIFF
--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -388,7 +388,14 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
             end
             -- Only migrate if not already in class rules
             if not rules[class][spellID] then
-              rules[class][spellID] = ruleData
+              -- Separate old flat data into settings/metadata
+              local settings = {
+                enabled = ruleData.enabled,
+                priority = ruleData.priority,
+                iconSize = ruleData.iconSize,
+                useGlobalIconSize = ruleData.useGlobalIconSize,
+              }
+              rules[class][spellID] = { settings = settings, metadata = {} }
             end
 
             -- Populate static spell metadata
@@ -397,14 +404,15 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
             local baseCooldown = baseCooldownMS and (baseCooldownMS / 1000) or 0
             local chargeInfo = C_Spell.GetSpellCharges(spellID)
             local info = C_Spell.GetSpellInfo(spellID)
-            rule.baseCooldown = baseCooldown
-            rule.hasCooldown = baseCooldown > 1.5
-            rule.hasCharges = chargeInfo ~= nil
-            rule.maxCharges = chargeInfo and chargeInfo.maxCharges or nil
-            rule.isInstantCast = info and info.castTime == 0 or false
-            rule.castTime = info and (info.castTime / 1000) or 0
-            rule.hasRange = info and info.maxRange > 0 or false
-            rule.maxRange = info and info.maxRange or 0
+            rule.metadata = rule.metadata or {}
+            rule.metadata.baseCooldown = baseCooldown
+            rule.metadata.hasCooldown = baseCooldown > 1.5
+            rule.metadata.hasCharges = chargeInfo ~= nil
+            rule.metadata.maxCharges = chargeInfo and chargeInfo.maxCharges or nil
+            rule.metadata.isInstantCast = info and info.castTime == 0 or false
+            rule.metadata.castTime = info and (info.castTime / 1000) or 0
+            rule.metadata.hasRange = info and info.maxRange > 0 or false
+            rule.metadata.maxRange = info and info.maxRange or 0
 
             rules[spellID] = nil -- Remove from old format
             migratedCount = migratedCount + 1
@@ -1384,7 +1392,8 @@ function CooldownCursor:GetSpellRule(spellID)
   if not C_SpellBook.IsSpellKnown(spellID) then return false end
 
   -- Return whether the spell is enabled
-  return rule.enabled ~= false, rule
+  local settings = rule.settings or {}
+  return settings.enabled ~= false, rule
 end
 
 -- Expose GetPlayerClass for Options.lua
@@ -1420,11 +1429,13 @@ local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
   if not iconFrame then return nil, nil end
 
   local _, rule = CooldownCursor:GetSpellRule(spellID)
-  local priority = (rule and rule.priority) or 0
+  local settings = rule and rule.settings or {}
+  local metadata = rule and rule.metadata or {}
+  local priority = settings.priority or 0
   local procActive = activeProcSpells[spellID] or false
 
   -- If this spell is an instant cast or has no cooldown, and it's not from a proc, don't create icon.
-  if not fromProc and rule and not rule.hasCooldown and not rule.hasCharges then
+  if not fromProc and rule and not metadata.hasCooldown and not metadata.hasCharges then
     return
   end
 
@@ -1608,7 +1619,7 @@ local function ApplyShowBehavior()
         -- If spell has no cooldown and user doesn't want to show procs, skip it
         if not CooldownCursorDB.global.showProcs and GetSpellBaseCooldown(spellID) == 0 then
           -- continue to next spell (can't use continue in Lua, so we use a nested if)
-        elseif rule.enabled ~= false and not activeIcons[spellID] and C_SpellBook.IsSpellKnown(spellID) then
+        elseif (rule.settings and rule.settings.enabled ~= false) and not activeIcons[spellID] and C_SpellBook.IsSpellKnown(spellID) then
           local durationObject = C_Spell.GetSpellCooldownDuration(spellID)
           if durationObject then
             ShowSpellIcon(spellID, durationObject)
@@ -1815,11 +1826,14 @@ function CooldownCursor:AddOrUpdateSpellRule(spellID, ruleData)
   local classRules = GetClassRules()
   if not classRules then return false, "Could not determine player class" end
 
-  classRules[spellID] = classRules[spellID] or {}
+  classRules[spellID] = classRules[spellID] or { settings = {}, metadata = {} }
+  local rule = classRules[spellID]
+  rule.settings = rule.settings or {}
+  rule.metadata = rule.metadata or {}
 
-  -- Apply user-provided rule data
+  -- Apply user-provided settings
   for k, v in pairs(ruleData or {}) do
-    classRules[spellID][k] = v
+    rule.settings[k] = v
   end
 
   -- Auto-populate static spell metadata
@@ -1828,15 +1842,14 @@ function CooldownCursor:AddOrUpdateSpellRule(spellID, ruleData)
   local chargeInfo = C_Spell.GetSpellCharges(spellID)
   local info = C_Spell.GetSpellInfo(spellID)
 
-  local rule = classRules[spellID]
-  rule.baseCooldown = baseCooldown
-  rule.hasCooldown = baseCooldown > 1.5
-  rule.hasCharges = chargeInfo ~= nil
-  rule.maxCharges = chargeInfo and chargeInfo.maxCharges or nil
-  rule.isInstantCast = info and info.castTime == 0 or false
-  rule.castTime = info and (info.castTime / 1000) or 0
-  rule.hasRange = info and info.maxRange > 0 or false
-  rule.maxRange = info and info.maxRange or 0
+  rule.metadata.baseCooldown = baseCooldown
+  rule.metadata.hasCooldown = baseCooldown > 1.5
+  rule.metadata.hasCharges = chargeInfo ~= nil
+  rule.metadata.maxCharges = chargeInfo and chargeInfo.maxCharges or nil
+  rule.metadata.isInstantCast = info and info.castTime == 0 or false
+  rule.metadata.castTime = info and (info.castTime / 1000) or 0
+  rule.metadata.hasRange = info and info.maxRange > 0 or false
+  rule.metadata.maxRange = info and info.maxRange or 0
 
   return true, spellName
 end
@@ -1858,11 +1871,11 @@ function CooldownCursor:GetEffectiveIconSize(spellID)
   if not classRules then return globalSize end
 
   local rule = classRules[spellID]
-  if not rule then return globalSize end
+  if not rule or not rule.settings then return globalSize end
 
-  if rule.useGlobalIconSize ~= false then return globalSize end
+  if rule.settings.useGlobalIconSize ~= false then return globalSize end
 
-  if rule.iconSize then return rule.iconSize end
+  if rule.settings.iconSize then return rule.settings.iconSize end
 
   return globalSize
 end
@@ -2123,14 +2136,15 @@ function CooldownCursor:PreviewMultiIcon()
     if classRules and next(classRules) then
       -- Use spells from user's class-specific spell rules
       for spellID, rule in pairs(classRules) do
-        if rule.enabled ~= false and C_SpellBook.IsSpellKnown(spellID) then
+        local ruleSettings = rule.settings or {}
+        if ruleSettings.enabled ~= false and C_SpellBook.IsSpellKnown(spellID) then
           local info = C_Spell.GetSpellInfo(spellID)
           if info then
             table.insert(previewSpells, {
               id = spellID,
               duration = 30 + (#previewSpells * 5), -- Vary durations
               name = info.name,
-              priority = rule.priority or 0,
+              priority = ruleSettings.priority or 0,
             })
           end
         end

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -1523,7 +1523,14 @@ local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
   CooldownCursor:UpdateSingleIcon(iconFrame, spellID)
 
   iconFrame.icon:SetTexture(spellInfo.iconID)
-  iconFrame.cooldown:SetCooldownFromDurationObject(durationObject)
+
+  -- Proc-only spells have no real cooldown - hide the timer overlay
+  if fromProc and not metadata.hasCooldown and not metadata.hasCharges then
+    iconFrame.cooldown:SetHideCountdownNumbers(true)
+    iconFrame.cooldown:SetDrawSwipe(false)
+  else
+    iconFrame.cooldown:SetCooldownFromDurationObject(durationObject)
+  end
 
   if CooldownCursorDB.global.showSpellNames and spellInfo.name then
     iconFrame.text:SetText(spellInfo.name)
@@ -2203,14 +2210,17 @@ function CooldownCursor:PreviewMultiIcon()
       -- Use spells from user's class-specific spell rules
       for spellID, rule in pairs(classRules) do
         local ruleSettings = rule.settings or {}
+        local metadata = rule.metadata or {}
         if ruleSettings.enabled ~= false and IsSpellKnownCached(spellID) then
           local info = C_Spell.GetSpellInfo(spellID)
           if info then
+            local isProc = not metadata.hasCooldown and not metadata.hasCharges
             table.insert(previewSpells, {
               id = spellID,
               duration = 30 + (#previewSpells * 5), -- Vary durations
               name = info.name,
               priority = ruleSettings.priority or 0,
+              isProc = isProc,
             })
           end
         end
@@ -2259,8 +2269,10 @@ function CooldownCursor:PreviewMultiIcon()
       local spellData = spellPool[i]
       local durationObj = C_DurationUtil.CreateDuration()
       durationObj:SetTimeFromStart(GetTime(), spellData.duration)
-      local iconFrame, iconData = ShowSpellIcon(spellData.id, durationObj)
-      ApplyPreviewProc(iconFrame, iconData)
+      local iconFrame, iconData = ShowSpellIcon(spellData.id, durationObj, spellData.isProc)
+      if spellData.isProc then
+        ApplyPreviewProc(iconFrame, iconData)
+      end
     end
     self:ApplyPreviewPosition()
   end

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -268,6 +268,54 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
     CooldownCursorDB._migratedWhitelist = true
   end
   ----------------------------------------------------------------------------------
+
+  ----------------------------------------------------------------------------------
+  -- migration v2.2.0 - Migrate old flat spell rules to class-based format ---------
+  -- Old format: rules[spellID] = {...}
+  -- New format: rules[CLASS][spellID] = {...}
+  -- This runs incrementally per character - only migrates spells the character knows
+  if not CooldownCursorDB._cleanedFlatRules then
+    local rules = CooldownCursorDB.spellRules and CooldownCursorDB.spellRules.rules
+    if rules then
+      local _, class = UnitClass("player")
+      local migratedCount = 0
+      local remainingCount = 0
+
+      -- First pass: migrate spells this character knows to their class
+      for key, ruleData in pairs(rules) do
+        if type(key) == "number" then
+          local spellID = key
+          if C_SpellBook.IsSpellKnown(spellID) and class then
+            -- This character knows this spell - migrate to class format
+            if not rules[class] then
+              rules[class] = {}
+            end
+            -- Only migrate if not already in class rules
+            if not rules[class][spellID] then
+              rules[class][spellID] = ruleData
+            end
+            rules[spellID] = nil -- Remove from old format
+            migratedCount = migratedCount + 1
+          else
+            -- This character doesn't know this spell - leave for another alt
+            remainingCount = remainingCount + 1
+          end
+        end
+      end
+
+      -- Only mark as done when no old-format rules remain
+      if remainingCount == 0 then
+        CooldownCursorDB._cleanedFlatRules = true
+      end
+
+      if migratedCount > 0 then
+        print("|cff00ff00CooldownCursor:|r Migrated " .. migratedCount .. " spell rules to " .. (class or "unknown") .. " format.")
+      end
+    else
+      -- No rules exist, mark as done
+      CooldownCursorDB._cleanedFlatRules = true
+    end
+  end
   ----------------------------------------------------------------------------------
 
   CooldownCursorDB._version = major
@@ -280,6 +328,16 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
   -- Notes are organized by version (newest first)
 
   local releaseNotesByVersion = {
+    ["2.2.0"] = {
+      breakingChanges = {
+        "Spell rules are now saved per class - you may need to re-add spells on alt characters",
+      },
+      newFeatures = {
+        "Class-based Spell Rules: Each class now has its own separate spell rules",
+        "Your Rogue won't see Warlock spells and vice versa!",
+      },
+      fixes = {},
+    },
     ["2.1.0"] = {
       breakingChanges = {
         "Simplified Spell Rules: Removed whitelist/blacklist mode - now uses simple enable/disable per spell",
@@ -1017,23 +1075,64 @@ local function EnforceMaxIcons()
 end
 
 ----------------------------------------------------
+-- Player Class Helper
+----------------------------------------------------
+local playerClass = nil
+
+local function GetPlayerClass()
+  if not playerClass then
+    local _, classToken = UnitClass("player")
+    playerClass = classToken
+  end
+  return playerClass
+end
+
+----------------------------------------------------
 -- Spell Rule Logic
 ----------------------------------------------------
+
+-- Get the rules table for the current player's class
+local function GetClassRules()
+  local data = CooldownCursorDB.spellRules
+  if not data then return nil end
+
+  local class = GetPlayerClass()
+  if not class then return nil end
+
+  -- Initialize class rules table if needed
+  if not data.rules then
+    data.rules = {}
+  end
+  if not data.rules[class] then
+    data.rules[class] = {}
+  end
+
+  return data.rules[class]
+end
+
 function CooldownCursor:GetSpellRule(spellID)
   local data = CooldownCursorDB.spellRules
-  if not data or not data.rules then return false end
-  if data.settings.disableRules then return true end
+  if not data then return false end
+  if data.settings and data.settings.disableRules then return true end
 
-  local rules = data.rules
-  -- If no rules exist, don't show any spells
-  if not next(rules) then return false end
+  local classRules = GetClassRules()
+  -- If no rules exist for this class, don't show any spells
+  if not classRules or not next(classRules) then return false end
 
-  local rule = rules[spellID]
+  local rule = classRules[spellID]
   -- If spell is not in rules, don't show it
   if not rule then return false end
 
+  -- If spell is not known to the player (wrong spec, etc.), don't show it
+  if not C_SpellBook.IsSpellKnown(spellID) then return false end
+
   -- Return whether the spell is enabled
   return rule.enabled ~= false, rule
+end
+
+-- Expose GetPlayerClass for Options.lua
+function CooldownCursor:GetPlayerClass()
+  return GetPlayerClass()
 end
 
 ----------------------------------------------------
@@ -1163,10 +1262,10 @@ local function ApplyShowBehavior()
   -- We need the icons to exist so their cooldown frames stay current
   -- and we can check IsShown() on each event.
   if showBehavior == SHOW_BEHAVIOR.OFF_COOLDOWN then
-    local rules = CooldownCursorDB.spellRules and CooldownCursorDB.spellRules.rules
-    if rules then
-      for spellID, rule in pairs(rules) do
-        if rule.enabled ~= false and not activeIcons[spellID] then
+    local classRules = GetClassRules()
+    if classRules then
+      for spellID, rule in pairs(classRules) do
+        if rule.enabled ~= false and not activeIcons[spellID] and C_SpellBook.IsSpellKnown(spellID) then
           local durationObject = C_Spell.GetSpellCooldownDuration(spellID)
           if durationObject then
             ShowSpellIcon(spellID, durationObject)
@@ -1316,19 +1415,24 @@ function CooldownCursor:AddOrUpdateSpellRule(spellID, ruleData)
   CooldownCursorDB.spellRules.settings = CooldownCursorDB.spellRules.settings or {}
   CooldownCursorDB.spellRules.rules = CooldownCursorDB.spellRules.rules or {}
 
-  local rules = CooldownCursorDB.spellRules.rules
-  rules[spellID] = rules[spellID] or {}
+  -- Get class-specific rules table
+  local classRules = GetClassRules()
+  if not classRules then return false, "Could not determine player class" end
+
+  classRules[spellID] = classRules[spellID] or {}
 
   for k, v in pairs(ruleData or {}) do
-    rules[spellID][k] = v
+    classRules[spellID][k] = v
   end
 
   return true, spellName
 end
 
 function CooldownCursor:RemoveSpellRule(spellID)
-  if not CooldownCursorDB.spellRules or not CooldownCursorDB.spellRules.rules then return end
-  CooldownCursorDB.spellRules.rules[spellID] = nil
+  local classRules = GetClassRules()
+  if not classRules then return end
+
+  classRules[spellID] = nil
   CooldownCursor:UpdateDisplay()
   CooldownCursor:RebuildSpellRuleOptions()
   CooldownCursor:NotifyOptionsChanged()
@@ -1581,12 +1685,14 @@ function CooldownCursor:PreviewMultiIcon()
   -- Build preview spell list from spell rules, or fall back to default pool
   local function GetPreviewSpells()
     local previewSpells = {}
-    local rules = CooldownCursorDB.spellRules and CooldownCursorDB.spellRules.rules
 
-    if rules and next(rules) then
-      -- Use spells from user's spell rules
-      for spellID, rule in pairs(rules) do
-        if rule.enabled ~= false then
+    -- Get class-specific rules
+    local classRules = GetClassRules()
+
+    if classRules and next(classRules) then
+      -- Use spells from user's class-specific spell rules
+      for spellID, rule in pairs(classRules) do
+        if rule.enabled ~= false and C_SpellBook.IsSpellKnown(spellID) then
           local info = C_Spell.GetSpellInfo(spellID)
           if info then
             table.insert(previewSpells, {

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -50,6 +50,8 @@ local activeSpellID = nil
 local inCombat = false
 local fontsTable = {}
 local previewMouseMode = true
+local activeProcSpells = {}
+local procCapableSpells = {}
 
 -- Multi-icon state
 local iconPool = {}
@@ -150,6 +152,39 @@ local STACK_GROWTH = {
   COUNTERCLOCKWISE = "COUNTERCLOCKWISE",
 }
 
+-----------------------------------------------------
+--- Proc Overlay/Outline Atlas Settings
+-----------------------------------------------------
+local PROC_OVERLAY_ATLAS_SETTINGS = {
+  ["ArtifactsFX-SpinningGlowys"] = { name = "Spinning Glowys", scale = 1.5 },
+  ["AftLevelup-WhiteStarBurst"] = { name = "Star Burst", scale = 2 },
+  ["ArtifactsFX-Whirls"] = { name = "Whirls", scale = 1.4 },
+}
+
+local PROC_OUTLINE_ATLAS_SETTINGS = {
+  ["combattimeline-fx-queued"] = { name = "Square Neon Glow", scale = 1.6 },
+  ["combattimeline-fx-deadlyglow-base"] = { name = "Square Glow", scale = 1.6 },
+  ["talents-node-choiceflyout-square-ghost"] = { name = "Square Dotted", scale = 1.2 },
+}
+
+function CooldownCursor:GetProcOverlayAtlasSettings()
+  return PROC_OVERLAY_ATLAS_SETTINGS
+end
+
+function CooldownCursor:GetProcOutlineAtlasSettings()
+  return PROC_OUTLINE_ATLAS_SETTINGS
+end
+
+local function IsProcOverlayEnabled()
+  local atlas = CooldownCursorDB.procOverlayAtlas or defaults.procOverlayAtlas
+  return atlas and atlas ~= "" and atlas ~= "none"
+end
+
+local function IsProcOutlineEnabled()
+  local atlas = CooldownCursorDB.procOutlineAtlas or defaults.procOutlineAtlas
+  return atlas and atlas ~= "" and atlas ~= "none"
+end
+
 ----------------------------------------------------
 -- Live Preview state
 ----------------------------------------------------
@@ -173,6 +208,11 @@ local defaults = {
   scale = 1,
   iconSize = 48,
   iconAlpha = 100,
+  showProcs = false,
+  procOverlayAtlas = "none",
+  procOutlineAtlas = "combattimeline-fx-queued",
+  procOverlayColor = "#FFFFFF",
+  procOutlineColor = "#FFFFFF",
   iconHide = false,
   showSpellNames = false,
   hideCooldownNumbers = false,
@@ -280,6 +320,18 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
   -- Notes are organized by version (newest first)
 
   local releaseNotesByVersion = {
+    ["2.2.0"] = {
+      newFeatures = {
+        "Proc Spell Support: Show spell icons when procs are active",
+        "Proc visual indicators with customizable overlay and border",
+      },
+      fixes = {},
+    },
+    ["2.1.2"] = {
+      fixes = {
+        "Minor bug fixes",
+      },
+    },
     ["2.1.1"] = {
       fixes = {
         "Fixed issue where some spell icons would show if not known by the player",
@@ -434,6 +486,28 @@ local function CreateIconFrame(index)
   iconFrame.primaryLabel:SetText("|cff00ff00PRIMARY|r")
   iconFrame.primaryLabel:Hide()
 
+  -- Proc overlay (SPELL_ACTIVATION_OVERLAY_GLOW_SHOW)
+  iconFrame.procOverlay = iconFrame:CreateTexture(nil, "OVERLAY")
+  local overlayAtlas = CooldownCursorDB.procOverlayAtlas or defaults.procOverlayAtlas
+  if IsProcOverlayEnabled() and overlayAtlas and overlayAtlas ~= "" then
+    iconFrame.procOverlay:SetAtlas(overlayAtlas, true)
+  end
+  iconFrame.procOverlay:SetBlendMode("ADD")
+  iconFrame.procOverlay:SetPoint("CENTER", iconFrame, "CENTER", 0, 0)
+  iconFrame.procOverlay:Hide()
+
+  -- Proc outline border
+  iconFrame.procOutline = iconFrame:CreateTexture(nil, "OVERLAY")
+  local outlineAtlas = CooldownCursorDB.procOutlineAtlas or defaults.procOutlineAtlas
+  if IsProcOutlineEnabled() and outlineAtlas and outlineAtlas ~= "" then
+    iconFrame.procOutline:SetAtlas(outlineAtlas, true)
+  end
+  iconFrame.procOutline:SetBlendMode("ADD")
+  iconFrame.procOutline:SetPoint("CENTER", iconFrame, "CENTER", 0, 0)
+  iconFrame.procOutline:SetAlpha(0.9)
+  iconFrame.procOutline:Hide()
+
+
   iconFrame.iconID = index
   iconFrame.spellID = nil
   iconFrame.addedTime = nil
@@ -441,6 +515,8 @@ local function CreateIconFrame(index)
   iconFrame.hideTimer = nil
   iconFrame.stackOffsetX = 0
   iconFrame.stackOffsetY = 0
+  iconFrame.procActive = false
+  iconFrame.procOnly = false
 
   return iconFrame
 end
@@ -483,6 +559,14 @@ function ReturnIconToPool(iconFrame)
   if iconFrame.primaryLabel then
     iconFrame.primaryLabel:Hide()
   end
+  if iconFrame.procOverlay then
+    iconFrame.procOverlay:Hide()
+  end
+  if iconFrame.procOutline then
+    iconFrame.procOutline:Hide()
+  end
+  iconFrame.procActive = false
+  iconFrame.procOnly = false
 
   if iconFrame.hideTimer then
     iconFrame.hideTimer:Cancel()
@@ -832,6 +916,29 @@ function CooldownCursor:UpdateSingleIcon(icon, spellID)
     icon.text:SetTextColor(textr, textg, textb, textAlpha)
   end
 
+  if icon.procOverlay then
+    local showProcs = CooldownCursorDB.showProcs ~= false
+    local showOverlay = IsProcOverlayEnabled()
+    local overlayAtlas = CooldownCursorDB.procOverlayAtlas or defaults.procOverlayAtlas
+    if overlayAtlas and overlayAtlas ~= "" then
+      icon.procOverlay:SetAtlas(overlayAtlas, true)
+    end
+    local orr, org, orb = HexToRGB(CooldownCursorDB.procOverlayColor or defaults.procOverlayColor)
+    icon.procOverlay:SetVertexColor(orr, org, orb, 1)
+    icon.procOverlay:SetShown(showProcs and showOverlay and (icon.procActive == true))
+  end
+  if icon.procOutline then
+    local showProcs = CooldownCursorDB.showProcs ~= false
+    local showOutline = IsProcOutlineEnabled()
+    local outlineAtlas = CooldownCursorDB.procOutlineAtlas or defaults.procOutlineAtlas
+    if outlineAtlas and outlineAtlas ~= "" then
+      icon.procOutline:SetAtlas(outlineAtlas, true)
+    end
+    local otr, otg, otb = HexToRGB(CooldownCursorDB.procOutlineColor or defaults.procOutlineColor)
+    icon.procOutline:SetVertexColor(otr, otg, otb, 1)
+    icon.procOutline:SetShown(showProcs and showOutline and (icon.procActive == true))
+  end
+
   local anchorPoint = SPELL_TEXT_ANCHOR_POINTS[string.upper(CooldownCursorDB.spellTextAnchor)]
       or SPELL_TEXT_ANCHOR_POINTS[string.upper(defaults.spellTextAnchor)]
   icon.text:ClearAllPoints()
@@ -842,6 +949,22 @@ function CooldownCursor:UpdateSingleIcon(icon, spellID)
   icon:SetSize(size * scale, size * scale)
   icon.text:SetScale(scale)
   icon.cooldown:SetScale(scale)
+  if icon.procOverlay then
+    local overlayAtlas = CooldownCursorDB.procOverlayAtlas or defaults.procOverlayAtlas
+    local overlayScale = 1.6
+    if overlayAtlas and PROC_OVERLAY_ATLAS_SETTINGS[overlayAtlas] then
+      overlayScale = PROC_OVERLAY_ATLAS_SETTINGS[overlayAtlas].scale or overlayScale
+    end
+    icon.procOverlay:SetSize(size * scale * overlayScale, size * scale * overlayScale)
+  end
+  if icon.procOutline then
+    local outlineAtlas = CooldownCursorDB.procOutlineAtlas or defaults.procOutlineAtlas
+    local outlineScale = 1.9
+    if outlineAtlas and PROC_OUTLINE_ATLAS_SETTINGS[outlineAtlas] then
+      outlineScale = PROC_OUTLINE_ATLAS_SETTINGS[outlineAtlas].scale or outlineScale
+    end
+    icon.procOutline:SetSize(size * scale * outlineScale, size * scale * outlineScale)
+  end
 
   icon.cooldown:SetHideCountdownNumbers(CooldownCursorDB.hideCooldownNumbers)
   icon.cooldown:SetDrawSwipe(CooldownCursorDB.showCooldownSwipe)
@@ -1046,12 +1169,13 @@ end
 ----------------------------------------------------
 -- Icon Setup Helper
 ----------------------------------------------------
-local function SetupNewIcon(spellID, spellInfo, durationObject)
+local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
   local iconFrame = GetIconFromPool()
   if not iconFrame then return nil, nil end
 
   local _, rule = CooldownCursor:GetSpellRule(spellID)
   local priority = (rule and rule.priority) or 0
+  local procActive = activeProcSpells[spellID] or false
 
   local iconData = {
     spellID = spellID,
@@ -1060,6 +1184,8 @@ local function SetupNewIcon(spellID, spellInfo, durationObject)
     spellName = spellInfo.name,
     addedTime = GetTime(),
     priority = priority,
+    procActive = procActive,
+    procOnly = fromProc == true,
   }
 
   activeIcons[spellID] = iconData
@@ -1068,6 +1194,8 @@ local function SetupNewIcon(spellID, spellInfo, durationObject)
   iconFrame.spellID = spellID
   iconFrame.addedTime = iconData.addedTime
   iconFrame.priority = priority
+  iconFrame.procActive = procActive
+  iconFrame.procOnly = fromProc == true
 
   CooldownCursor:UpdateSingleIcon(iconFrame, spellID)
 
@@ -1090,6 +1218,16 @@ local function SetupNewIcon(spellID, spellInfo, durationObject)
   iconFrame.icon:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha))
   iconFrame:SetScript("OnUpdate", UpdateCooldownIconFrame)
   iconFrame:Show()
+  if iconFrame.procOverlay then
+    local showProcs = CooldownCursorDB.showProcs ~= false
+    local showOverlay = IsProcOverlayEnabled()
+    iconFrame.procOverlay:SetShown(showProcs and showOverlay and procActive)
+  end
+  if iconFrame.procOutline then
+    local showProcs = CooldownCursorDB.showProcs ~= false
+    local showOutline = IsProcOutlineEnabled()
+    iconFrame.procOutline:SetShown(showProcs and showOutline and procActive)
+  end
 
   return iconFrame, iconData
 end
@@ -1097,14 +1235,14 @@ end
 ----------------------------------------------------
 -- Show icon + cooldown
 ----------------------------------------------------
-local function ShowSpellIcon(spellID, durationObject)
+local function ShowSpellIcon(spellID, durationObject, fromProc)
   -- Don't create icons if addon is disabled
   if CooldownCursorDB.enabled == false then
-    return
+    return nil, nil
   end
 
   local spellInfo = C_Spell.GetSpellInfo(spellID)
-  if not spellInfo or not spellInfo.iconID then return end
+  if not spellInfo or not spellInfo.iconID then return nil, nil end
 
   local stackDirection = CooldownCursorDB.stackDirection or defaults.stackDirection
   local isSingleMode = (stackDirection == STACK_DIRECTION.SINGLE)
@@ -1117,11 +1255,11 @@ local function ShowSpellIcon(spellID, durationObject)
       end
     end
 
-    local iconFrame = SetupNewIcon(spellID, spellInfo, durationObject)
+    local iconFrame, iconData = SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
     if iconFrame then
       ScheduleHideTimerForIcon(iconFrame, spellID)
     end
-    return
+    return iconFrame, iconData
   end
 
   if CooldownCursor:IsMultiIconEnabled() then
@@ -1131,20 +1269,40 @@ local function ShowSpellIcon(spellID, durationObject)
       local iconFrame = existingIcon.iconFrame
       iconFrame.cooldown:SetCooldownFromDurationObject(durationObject)
       existingIcon.durationObject = durationObject
+      if not fromProc then
+        existingIcon.procOnly = false
+        iconFrame.procOnly = false
+      end
+      if activeProcSpells[spellID] and CooldownCursorDB.showProcs ~= false then
+        existingIcon.procActive = true
+        iconFrame.procActive = true
+        if iconFrame.procOverlay then
+          if IsProcOverlayEnabled() then
+            iconFrame.procOverlay:Show()
+          else
+            iconFrame.procOverlay:Hide()
+          end
+        end
+        if iconFrame.procOutline and IsProcOutlineEnabled() then
+          iconFrame.procOutline:Show()
+        end
+      end
       ScheduleHideTimerForIcon(iconFrame, spellID)
       SortIcons()
       UpdateIconPositions()
-      return -- caller will run ApplyShowBehavior() after us
+      return iconFrame, existingIcon -- caller will run ApplyShowBehavior() after us
     end
 
-    local iconFrame = SetupNewIcon(spellID, spellInfo, durationObject)
+    local iconFrame, iconData = SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
     if iconFrame then
       SortIcons()
       UpdateIconPositions()
       EnforceMaxIcons()
       ScheduleHideTimerForIcon(iconFrame, spellID)
     end
+    return iconFrame, iconData
   end
+  return nil, nil
 end
 
 ----------------------------------------------------
@@ -1163,6 +1321,21 @@ local function ApplyShowBehavior()
 
   -- AUTO_HIDE_AFTER - nothing extra to do here
   if showBehavior == SHOW_BEHAVIOR.AUTO_HIDE_AFTER then
+    -- If a spell can proc, only show it while the proc is active
+    if CooldownCursorDB.showProcs ~= false then
+      for spellID, iconData in pairs(activeIcons) do
+        local iconFrame = iconData.iconFrame
+        if iconFrame and procCapableSpells[spellID] then
+          local isProcActive = iconData.procActive or iconFrame.procActive
+          if isProcActive then
+            iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
+          else
+            iconFrame:SetAlpha(0)
+          end
+        end
+      end
+      UpdateIconPositions()
+    end
     return
   end
 
@@ -1173,9 +1346,13 @@ local function ApplyShowBehavior()
     local rules = CooldownCursorDB.spellRules and CooldownCursorDB.spellRules.rules
     if rules then
       for spellID, rule in pairs(rules) do
-        if rule.enabled ~= false and not activeIcons[spellID] and IsPlayerSpell(spellID) then
+        -- If spell has no cooldown and user doesn't want to show procs, skip it
+        if not CooldownCursorDB.showProcs and GetSpellBaseCooldown(spellID) == 0 then
+          return
+        end
+        if rule.enabled ~= false and not activeIcons[spellID] and type(spellID) == "number" then
           local durationObject = C_Spell.GetSpellCooldownDuration(spellID)
-          if durationObject then
+          if durationObject and IsPlayerSpell(spellID) then
             ShowSpellIcon(spellID, durationObject)
           end
         end
@@ -1192,22 +1369,27 @@ local function ApplyShowBehavior()
     local iconFrame = iconData.iconFrame
     if iconFrame then
       local isOnCooldown = iconFrame.cooldown:IsShown()
+      local isProcActive = (CooldownCursorDB.showProcs ~= false) and (iconData.procActive or iconFrame.procActive)
 
       -- Reset alpha in case it was modified in OFF_COOLDOWN mode
-      if isOnCooldown then
+      if isOnCooldown or isProcActive then
         iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
       end
 
       if showBehavior == SHOW_BEHAVIOR.ON_COOLDOWN then
         -- ON_COOLDOWN: icon should only be visible while on cooldown.
         -- Mark for removal once the cooldown ends.
-        if not isOnCooldown then
+        if not isOnCooldown and not isProcActive then
           table.insert(toRemove, spellID)
         end
       elseif showBehavior == SHOW_BEHAVIOR.OFF_COOLDOWN then
         -- OFF_COOLDOWN: icon should only be visible when ready.
         -- Use SetAlpha so the cooldown frame stays alive and keeps updating.
-        if isOnCooldown then
+        if (CooldownCursorDB.showProcs ~= false) and procCapableSpells[spellID] and not isProcActive then
+          iconFrame:SetAlpha(0)
+        elseif isProcActive then
+          iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
+        elseif isOnCooldown then
           iconFrame:SetAlpha(0)
         else
           iconFrame:SetAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha)
@@ -1310,6 +1492,32 @@ end
 function CooldownCursor:SetDBBoolean(key, value)
   CooldownCursorDB[key] = value and true or false
   self:UpdateDisplay()
+end
+
+function CooldownCursor:ClearProcStates(removeProcOnly)
+  activeProcSpells = {}
+  procCapableSpells = {}
+  local toRemove = {}
+
+  for spellID, iconData in pairs(activeIcons) do
+    iconData.procActive = false
+    if iconData.iconFrame then
+      iconData.iconFrame.procActive = false
+      if iconData.iconFrame.procOverlay then
+        iconData.iconFrame.procOverlay:Hide()
+      end
+      if iconData.iconFrame.procOutline then
+        iconData.iconFrame.procOutline:Hide()
+      end
+    end
+    if removeProcOnly and iconData.procOnly then
+      table.insert(toRemove, spellID)
+    end
+  end
+
+  for _, spellID in ipairs(toRemove) do
+    RemoveIconForSpell(spellID, true)
+  end
 end
 
 function CooldownCursor:AddOrUpdateSpellRule(spellID, ruleData)
@@ -1554,10 +1762,32 @@ function CooldownCursor:Preview()
     return
   end
 
+  local function ApplyPreviewProc(iconFrame, iconData)
+    if not iconFrame or not iconData then return end
+    if CooldownCursorDB.showProcs == false then return end
+    iconData.procActive = true
+    iconFrame.procActive = true
+    if iconFrame.procOverlay then
+      if IsProcOverlayEnabled() then
+        iconFrame.procOverlay:Show()
+      else
+        iconFrame.procOverlay:Hide()
+      end
+    end
+    if iconFrame.procOutline then
+      if IsProcOutlineEnabled() then
+        iconFrame.procOutline:Show()
+      else
+        iconFrame.procOutline:Hide()
+      end
+    end
+  end
+
   local function ShowPreviewIcon()
     local durationObj = C_DurationUtil.CreateDuration()
     durationObj:SetTimeFromStart(GetTime(), 30)
-    ShowSpellIcon(116, durationObj) -- Frostbolt
+    local iconFrame, iconData = ShowSpellIcon(116, durationObj) -- Frostbolt
+    ApplyPreviewProc(iconFrame, iconData)
     self:ApplyPreviewPosition()
   end
 
@@ -1593,9 +1823,9 @@ function CooldownCursor:PreviewMultiIcon()
     if rules and next(rules) then
       -- Use spells from user's spell rules
       for spellID, rule in pairs(rules) do
-        if rule.enabled ~= false and IsPlayerSpell(spellID) then
+        if rule.enabled ~= false and type(spellID) == "number" then
           local info = C_Spell.GetSpellInfo(spellID)
-          if info then
+          if info and IsPlayerSpell(spellID) then
             table.insert(previewSpells, {
               id = spellID,
               duration = 30 + (#previewSpells * 5), -- Vary durations
@@ -1619,6 +1849,27 @@ function CooldownCursor:PreviewMultiIcon()
     return previewSpells
   end
 
+  local function ApplyPreviewProc(iconFrame, iconData)
+    if not iconFrame or not iconData then return end
+    if CooldownCursorDB.showProcs == false then return end
+    iconData.procActive = true
+    iconFrame.procActive = true
+    if iconFrame.procOverlay then
+      if IsProcOverlayEnabled() then
+        iconFrame.procOverlay:Show()
+      else
+        iconFrame.procOverlay:Hide()
+      end
+    end
+    if iconFrame.procOutline then
+      if IsProcOutlineEnabled() then
+        iconFrame.procOutline:Show()
+      else
+        iconFrame.procOutline:Hide()
+      end
+    end
+  end
+
   local function ShowPreviewIcons()
     local maxIcons = self:GetDBValue("maxIcons")
     local spellPool = GetPreviewSpells()
@@ -1628,7 +1879,8 @@ function CooldownCursor:PreviewMultiIcon()
       local spellData = spellPool[i]
       local durationObj = C_DurationUtil.CreateDuration()
       durationObj:SetTimeFromStart(GetTime(), spellData.duration)
-      ShowSpellIcon(spellData.id, durationObj)
+      local iconFrame, iconData = ShowSpellIcon(spellData.id, durationObj)
+      ApplyPreviewProc(iconFrame, iconData)
     end
     self:ApplyPreviewPosition()
   end
@@ -1674,7 +1926,6 @@ end
 -- Event handler
 ----------------------------------------------------
 CooldownCursor:SetScript("OnEvent", function(self, event, ...)
-  local spellID
   local unit
   local SPELL_EVENTS = {
     UNIT_SPELLCAST_FAILED = true,
@@ -1693,6 +1944,63 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
     self:UnregisterEvent("ADDON_LOADED")
     return
   end
+
+  if event == "SPELL_ACTIVATION_OVERLAY_GLOW_SHOW" then
+    local spellID = ...
+    if not spellID then return end
+    if CooldownCursorDB.showProcs == false then return end
+    if not IsPlayerSpell(spellID) then return end
+    local show = CooldownCursor:GetSpellRule(spellID)
+    if not show then return end
+    activeProcSpells[spellID] = true
+    procCapableSpells[spellID] = true
+    local durationObj = C_Spell.GetSpellCooldownDuration(spellID)
+    local hadIcon = activeIcons[spellID] ~= nil
+    local iconFrame, iconData = ShowSpellIcon(spellID, durationObj, true)
+    if iconFrame and iconData then
+      iconData.procActive = true
+      iconFrame.procActive = true
+      if not hadIcon then
+        iconData.procOnly = true
+        iconFrame.procOnly = true
+      end
+      if iconFrame.procOverlay then
+        if IsProcOverlayEnabled() then
+          iconFrame.procOverlay:Show()
+        else
+          iconFrame.procOverlay:Hide()
+        end
+      end
+      if iconFrame.procOutline and IsProcOutlineEnabled() then
+        iconFrame.procOutline:Show()
+      end
+    end
+    return
+  end
+
+  if event == "SPELL_ACTIVATION_OVERLAY_GLOW_HIDE" then
+    local spellID = ...
+    if not spellID then return end
+    if CooldownCursorDB.showProcs == false then return end
+    activeProcSpells[spellID] = nil
+    local iconData = activeIcons[spellID]
+    if iconData and iconData.iconFrame then
+      local iconFrame = iconData.iconFrame
+      iconData.procActive = false
+      iconFrame.procActive = false
+      if iconFrame.procOverlay then
+        iconFrame.procOverlay:Hide()
+      end
+      if iconFrame.procOutline then
+        iconFrame.procOutline:Hide()
+      end
+      if iconData.procOnly then
+        RemoveIconForSpell(spellID, true)
+      end
+    end
+    return
+  end
+
   if event == "PLAYER_REGEN_DISABLED" then
     -- Entering combat
     inCombat = true
@@ -1722,6 +2030,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
   end
 
   if SPELL_EVENTS[event] then
+    local spellID
     -- Check if addon is enabled
     if CooldownCursorDB.enabled == false then
       return
@@ -1781,6 +2090,10 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
       local show, rule = CooldownCursor:GetSpellRule(spellID)
       if not show then return end
 
+      -- If spell has no cooldown and user doesn't want to show procs, skip it
+      if not CooldownCursorDB.showProcs and GetSpellBaseCooldown(spellID) == 0 then
+        return
+      end
       if durationObj then
         ShowSpellIcon(spellID, durationObj)
       end
@@ -1801,3 +2114,7 @@ CooldownCursor:RegisterEvent("SPELL_UPDATE_USABLE")
 CooldownCursor:RegisterEvent("UNIT_SPELLCAST_FAILED")
 CooldownCursor:RegisterEvent("PLAYER_REGEN_DISABLED")
 CooldownCursor:RegisterEvent("PLAYER_REGEN_ENABLED")
+CooldownCursor:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_SHOW")
+CooldownCursor:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_HIDE")
+
+

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -66,9 +66,9 @@ local SHOW_WHEN_STATE = {
 }
 
 local SHOW_BEHAVIOR = {
-  AUTO_HIDE_AFTER = 0, -- Show on cooldown, auto-hide after X seconds (default, original behaviour)
-  ON_COOLDOWN = 1,     -- Show on cooldown, remove icon when spell comes off cooldown
-  OFF_COOLDOWN = 2,    -- Show only when spell is ready (off cooldown)
+  ON_COOLDOWN = 0,     -- Show on cooldown, remove icon when spell comes off cooldown
+  OFF_COOLDOWN = 1,    -- Show only when spell is ready (off cooldown)
+  AUTO_HIDE_AFTER = 3, -- Show on cooldown, auto-hide after X seconds (default, original behaviour)
 }
 
 local ANCHOR_POSITION = {
@@ -221,7 +221,7 @@ local defaults = {
   animation = false,
   fadeOutDuration = 0,
   showWhen = SHOW_WHEN_STATE.COMBAT,
-  showBehavior = SHOW_BEHAVIOR.AUTO_HIDE_AFTER,
+  showBehavior = SHOW_BEHAVIOR.ON_COOLDOWN,
   hideWhileMounted = false,
   anchor = ANCHOR_POSITION.TOPRIGHT,
   anchorPadding = 2,
@@ -1433,7 +1433,7 @@ local function ApplyShowBehavior()
           -- continue to next spell (can't use continue in Lua, so we use a nested if)
         elseif rule.enabled ~= false and not activeIcons[spellID] and C_SpellBook.IsSpellKnown(spellID) then
           local durationObject = C_Spell.GetSpellCooldownDuration(spellID)
-          if durationObject and IsPlayerSpell(spellID) then
+          if durationObject then
             ShowSpellIcon(spellID, durationObject)
           end
         end
@@ -1637,11 +1637,11 @@ end
 
 function CooldownCursor:GetEffectiveIconSize(spellID)
   local globalSize = self:GetDBValue("iconSize")
-  local rulesData = CooldownCursorDB.spellRules
+  local classRules = GetClassRules()
 
-  if not rulesData or not rulesData.rules then return globalSize end
+  if not classRules then return globalSize end
 
-  local rule = rulesData.rules[spellID]
+  local rule = classRules[spellID]
   if not rule then return globalSize end
 
   if rule.useGlobalIconSize ~= false then return globalSize end
@@ -1913,7 +1913,7 @@ function CooldownCursor:PreviewMultiIcon()
       for spellID, rule in pairs(classRules) do
         if rule.enabled ~= false and C_SpellBook.IsSpellKnown(spellID) then
           local info = C_Spell.GetSpellInfo(spellID)
-          if info and IsPlayerSpell(spellID) then
+          if info then
             table.insert(previewSpells, {
               id = spellID,
               duration = 30 + (#previewSpells * 5), -- Vary durations

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -819,10 +819,10 @@ local function AnchorOffsets(anchor, size, pad)
 end
 
 local function RefreshCachedSettings()
-  cachedIconSize = CooldownCursorDB.iconSize or defaults.iconSize
-  cachedAnchorPadding = CooldownCursorDB.anchorPadding or defaults.anchorPadding
-  cachedAnchor = CooldownCursorDB.anchor or defaults.anchor
-  cachedIconHide = CooldownCursorDB.iconHide or false
+  cachedIconSize = CooldownCursorDB.global.iconSize or defaults.iconSize
+  cachedAnchorPadding = CooldownCursorDB.global.anchorPadding or defaults.anchorPadding
+  cachedAnchor = CooldownCursorDB.global.anchor or defaults.anchor
+  cachedIconHide = CooldownCursorDB.global.iconHide or false
   cachedAnchorOX, cachedAnchorOY = AnchorOffsets(cachedAnchor, cachedIconSize, cachedAnchorPadding)
   cachedHalfSize = cachedIconSize / 2
 end
@@ -1223,7 +1223,7 @@ function CooldownCursor:UpdateSingleIcon(icon, spellID)
   end
 
   -- Apply Masque iconHide override (ReSkin is called once in UpdateDisplay)
-  if MasqueGroup and CooldownCursorDB.iconHide then
+  if MasqueGroup and CooldownCursorDB.global.iconHide then
     icon.icon:SetAlpha(0)
   end
 end

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -221,6 +221,7 @@ local defaults = {
   iconSize = 48,
   iconAlpha = 100,
   showProcs = false,
+  showCharges = true,
   procOverlayAtlas = "none",
   procOutlineAtlas = "combattimeline-fx-queued",
   procOverlayColor = "#FFFFFF",
@@ -507,8 +508,11 @@ local function CreateIconFrame(index)
   iconFrame.text:SetPoint("BOTTOM", iconFrame, "TOP", 0, 4)
   iconFrame.text:Hide()
 
-  -- Charge count text (parented to cooldown frame so it draws above the swipe)
-  iconFrame.chargeText = iconFrame.cooldown:CreateFontString(nil, "OVERLAY")
+  -- Overlay frame for charge text (sits above cooldown swipe, independent of cooldown lifecycle)
+  iconFrame.chargeOverlay = CreateFrame("Frame", nil, iconFrame)
+  iconFrame.chargeOverlay:SetAllPoints(iconFrame)
+  iconFrame.chargeOverlay:SetFrameLevel(iconFrame.cooldown:GetFrameLevel() + 1)
+  iconFrame.chargeText = iconFrame.chargeOverlay:CreateFontString(nil, "OVERLAY")
   iconFrame.chargeText:Hide()
 
   iconFrame.showAnim = iconFrame:CreateAnimationGroup()
@@ -1298,6 +1302,11 @@ end
 local function UpdateChargeCount(iconFrame, spellID)
   if not iconFrame or not iconFrame.chargeText then return end
 
+  if CooldownCursorDB.showCharges == false then
+    iconFrame.chargeText:Hide()
+    return
+  end
+
   local chargeInfo = C_Spell.GetSpellCharges(spellID)
   if chargeInfo then
     iconFrame.chargeText:SetText(chargeInfo.currentCharges)
@@ -1311,7 +1320,6 @@ end
 -- Icon Setup Helper
 ----------------------------------------------------
 local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
-  print("Setting up new icon for spellID", spellID, "fromProc:", fromProc)
   local iconFrame = GetIconFromPool()
   if not iconFrame then return nil, nil end
 
@@ -1517,6 +1525,9 @@ local function ApplyShowBehavior()
       local isOnCooldown = iconFrame.cooldown:IsShown()
       local isProcActive = (CooldownCursorDB.showProcs ~= false) and (iconData.procActive or iconFrame.procActive)
 
+      -- Update charge count text
+      UpdateChargeCount(iconFrame, spellID)
+
       -- Reset alpha in case it was modified in OFF_COOLDOWN mode
       if isOnCooldown or isProcActive then
         iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
@@ -1539,8 +1550,13 @@ local function ApplyShowBehavior()
           -- Proc-only spell (no cooldown) not currently proccing - hide
           iconFrame:SetAlpha(0)
         elseif isOnCooldown then
-          -- On cooldown - hide
-          iconFrame:SetAlpha(0)
+          -- On cooldown - but if spell has charges available, still show it
+          local chargeInfo = CooldownCursorDB.showCharges ~= false and C_Spell.GetSpellCharges(spellID)
+          if chargeInfo and chargeInfo.currentCharges then
+            iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
+          else
+            iconFrame:SetAlpha(0)
+          end
         else
           -- Off cooldown and ready - show
           iconFrame:SetAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha)
@@ -2216,11 +2232,6 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
     end
     if not spellID then return end
 
-    if activeIcons[spellID] then
-      UpdateChargeCount(activeIcons[spellID].iconFrame, spellID)
-      ApplyShowBehavior()
-    end
-
     -- Check user spell rules before doing any cooldown queries
     local show, _ = CooldownCursor:GetSpellRule(spellID)
     if not show then return end
@@ -2228,22 +2239,13 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
     -- Delay slightly to allow cooldown to register
     C_Timer.After(0.01, function()
       local durationObj = C_Spell.GetSpellCooldownDuration(spellID)
+      local hasCharges = C_Spell.GetSpellCharges(spellID) ~= nil
 
       if not durationObj then return end
 
       -- Filter out non-cooldown abilities (buffs, mounts, etc.).
       if durationObj and not durationObj:HasSecretValues()
           and durationObj:GetStartTime() == 0 then
-        return
-      end
-
-      -- If spell has charges, show the icon regardless of cooldown state and update charge count
-      local chargeInfo = C_Spell.GetSpellCharges(spellID)
-      if chargeInfo then
-        local iconFrame, iconData = ShowSpellIcon(spellID, durationObj)
-        if iconFrame and iconData then
-          UpdateChargeCount(iconFrame, spellID)
-        end 
         return
       end
 
@@ -2256,6 +2258,13 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
         return
       end
 
+      if hasCharges then
+        local iconFrame, _ = ShowSpellIcon(spellID, durationObj)
+        UpdateChargeCount(iconFrame, spellID)
+        ApplyShowBehavior()
+        return
+      end
+
       -- If spell has no base cooldown, it's a proc spell
       -- Only show it if procs are enabled AND the spell is currently proccing
       if GetSpellBaseCooldown(spellID) == 0 then
@@ -2263,6 +2272,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
           return
         end
       end
+
       if durationObj then
         ShowSpellIcon(spellID, durationObj)
       end

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -288,9 +288,26 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
   -- 1. Apply any breaking changes to CooldownCursorDB (migrations)
   -- 2. Set release notes for display in Options UI
 
+  -- Migrate old flags into _migrated table (must run first)
+  if CooldownCursorDB._migrated == nil then
+    CooldownCursorDB._migrated = {}
+    if CooldownCursorDB._version then
+      CooldownCursorDB._migrated.version = CooldownCursorDB._version
+      CooldownCursorDB._version = nil
+    end
+    if CooldownCursorDB._migratedWhitelist then
+      CooldownCursorDB._migrated.whitelist = CooldownCursorDB._migratedWhitelist
+      CooldownCursorDB._migratedWhitelist = nil
+    end
+    if CooldownCursorDB._cleanedFlatRules then
+      CooldownCursorDB._migrated.cleanedFlatRules = CooldownCursorDB._cleanedFlatRules
+      CooldownCursorDB._cleanedFlatRules = nil
+    end
+  end
+
   -- Initialize version if missing
-  if not CooldownCursorDB._version then
-    CooldownCursorDB._version = 0
+  if not CooldownCursorDB._migrated.version then
+    CooldownCursorDB._migrated.version = 0
   end
 
   -- ========================================
@@ -306,7 +323,7 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
 
   ----------------------------------------------------------------------------------
   -- migration from version 1 to 2 -------------------------------------------------
-  if CooldownCursorDB._version < 2 then
+  if CooldownCursorDB._migrated.version < 2 then
     -- Run breaking changes here
     if CooldownCursorDB.showWhen == SHOW_WHEN_STATE.ALWAYS then
       CooldownCursorDB.showWhen = SHOW_WHEN_STATE.COMBAT
@@ -320,12 +337,12 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
 
   ----------------------------------------------------------------------------------
   -- migration v2.1.0 - Remove whitelist setting -----------------------------------
-  if not CooldownCursorDB._migratedWhitelist then
+  if not CooldownCursorDB._migrated.whitelist then
     -- Remove deprecated whitelist setting from spell rules
     if CooldownCursorDB.spellRules and CooldownCursorDB.spellRules.settings then
       CooldownCursorDB.spellRules.settings.whitelist = nil
     end
-    CooldownCursorDB._migratedWhitelist = true
+    CooldownCursorDB._migrated.whitelist = true
   end
   ----------------------------------------------------------------------------------
 
@@ -334,7 +351,7 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
   -- Old format: rules[spellID] = {...}
   -- New format: rules[CLASS][spellID] = {...}
   -- This runs incrementally per character - only migrates spells the character knows
-  if not CooldownCursorDB._cleanedFlatRules then
+  if not CooldownCursorDB._migrated.cleanedFlatRules then
     local rules = CooldownCursorDB.spellRules and CooldownCursorDB.spellRules.rules
     if rules then
       local _, class = UnitClass("player")
@@ -381,7 +398,7 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
 
       -- Only mark as done when no old-format rules remain
       if remainingCount == 0 then
-        CooldownCursorDB._cleanedFlatRules = true
+        CooldownCursorDB._migrated.cleanedFlatRules = true
       end
 
       if migratedCount > 0 then
@@ -389,12 +406,12 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
       end
     else
       -- No rules exist, mark as done
-      CooldownCursorDB._cleanedFlatRules = true
+      CooldownCursorDB._migrated.cleanedFlatRules = true
     end
   end
   ----------------------------------------------------------------------------------
 
-  CooldownCursorDB._version = major
+  CooldownCursorDB._migrated.version = major
 
   -- ========================================
   -- RELEASE NOTES (Display Only)
@@ -403,7 +420,7 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
   -- No code execution, just messages
   -- Notes are organized by version (newest first)
 
-  local _cleanedFlatRulesCheckMsg = CooldownCursorDB._cleanedFlatRules and "Your migration is marked cleaned" or "Your migration rules are pending cleanup"
+  local _cleanedFlatRulesCheckMsg = CooldownCursorDB._migrated.cleanedFlatRules and "Your migration is marked cleaned" or "Your migration rules are pending cleanup"
   local releaseNotesByVersion = {
     ["2.2.0"] = {
       breakingChanges = {
@@ -1901,14 +1918,14 @@ end
 
 function CooldownCursor:ResetSettings()
   local rules = CooldownCursorDB.spellRules
-  local major = tonumber(self:GetMajorVersion()) or 0
+  local _migrated = CooldownCursorDB._migrated
   CooldownCursor:HideIconNow()
   CooldownCursorDB = {}
   self:ApplyDefaults()
   self:UpdateDisplay()
   CooldownCursor:SetPreviewMouseMode(true)
   CooldownCursorDB.spellRules = rules
-  CooldownCursorDB._version = major
+  CooldownCursorDB._migrated = _migrated
 end
 
 ----------------------------------------------------

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -1704,9 +1704,26 @@ function CooldownCursor:AddOrUpdateSpellRule(spellID, ruleData)
 
   classRules[spellID] = classRules[spellID] or {}
 
+  -- Apply user-provided rule data
   for k, v in pairs(ruleData or {}) do
     classRules[spellID][k] = v
   end
+
+  -- Auto-populate static spell metadata
+  local baseCooldownMS, _ = GetSpellBaseCooldown(spellID)
+  local baseCooldown = baseCooldownMS and (baseCooldownMS / 1000) or 0
+  local chargeInfo = C_Spell.GetSpellCharges(spellID)
+  local info = C_Spell.GetSpellInfo(spellID)
+
+  local rule = classRules[spellID]
+  rule.baseCooldown = baseCooldown
+  rule.hasCooldown = baseCooldown > 1.5
+  rule.hasCharges = chargeInfo ~= nil
+  rule.maxCharges = chargeInfo and chargeInfo.maxCharges or nil
+  rule.isInstantCast = info and info.castTime == 0 or false
+  rule.castTime = info and (info.castTime / 1000) or 0
+  rule.hasRange = info and info.maxRange > 0 or false
+  rule.maxRange = info and info.maxRange or 0
 
   return true, spellName
 end

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -109,6 +109,18 @@ local SPELL_TEXT_ANCHOR_POINTS = {
   TOP = { point = "BOTTOM", relativeTo = "TOP", x = 0, y = 4 },
 }
 
+local CHARGE_TEXT_ANCHOR_POINTS = {
+  TOP = { point = "TOP", x = 0, y = -2 },
+  BOTTOM = { point = "BOTTOM", x = 0, y = 2 },
+  LEFT = { point = "LEFT", x = 2, y = 0 },
+  RIGHT = { point = "RIGHT", x = -2, y = 0 },
+  CENTER = { point = "CENTER", x = 0, y = 0 },
+  TOPLEFT = { point = "TOPLEFT", x = 2, y = -2 },
+  TOPRIGHT = { point = "TOPRIGHT", x = -2, y = -2 },
+  BOTTOMLEFT = { point = "BOTTOMLEFT", x = 2, y = 2 },
+  BOTTOMRIGHT = { point = "BOTTOMRIGHT", x = -2, y = 2 },
+}
+
 local FONT_TYPES = {
   NONE = nil,
   OUTLINE = "OUTLINE",
@@ -239,6 +251,13 @@ local defaults = {
   cooldownTextColor = "#FFFFFF",
   cooldownTextAnchor = CD_TEXT_ANCHOR_POINTS.CENTER.point,
   cooldownTextAlpha = 100,
+  chargeTextSize = 12,
+  chargeTextFont = "Friz Quadrata TT",
+  chargeTextFontPath = DEFAULT_SYSTEM_FONTS["Friz Quadrata TT"],
+  chargeTextFontType = FONT_TYPES.OUTLINE,
+  chargeTextColor = "#FFFFFF",
+  chargeTextAnchor = CHARGE_TEXT_ANCHOR_POINTS.BOTTOMRIGHT.point,
+  chargeTextAlpha = 100,
   frameStrata = FRAME_STRATA.HIGH,
   spellRules = spellRules,
 
@@ -488,9 +507,8 @@ local function CreateIconFrame(index)
   iconFrame.text:SetPoint("BOTTOM", iconFrame, "TOP", 0, 4)
   iconFrame.text:Hide()
 
-  -- Charge count text (bottom-right corner, like default WoW action bars)
-  iconFrame.chargeText = iconFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
-  iconFrame.chargeText:SetPoint("BOTTOMRIGHT", iconFrame, "BOTTOMRIGHT", -2, 2)
+  -- Charge count text
+  iconFrame.chargeText = iconFrame:CreateFontString(nil, "OVERLAY")
   iconFrame.chargeText:Hide()
 
   iconFrame.showAnim = iconFrame:CreateAnimationGroup()
@@ -964,6 +982,23 @@ function CooldownCursor:UpdateSingleIcon(icon, spellID)
     local textr, textg, textb = HexToRGB(CooldownCursorDB.spellTextColor or defaults.spellTextColor)
     local textAlpha = PercentToAlpha(CooldownCursorDB.spellTextAlpha or defaults.spellTextAlpha)
     icon.text:SetTextColor(textr, textg, textb, textAlpha)
+  end
+
+  if icon.chargeText then
+    ApplyFonts(
+      icon.chargeText,
+      CooldownCursorDB.chargeTextFontPath or defaults.chargeTextFontPath,
+      CooldownCursorDB.chargeTextSize or defaults.chargeTextSize,
+      CooldownCursorDB.chargeTextFontType or defaults.chargeTextFontType
+    )
+
+    local chr, chg, chb = HexToRGB(CooldownCursorDB.chargeTextColor or defaults.chargeTextColor)
+    local chAlpha = PercentToAlpha(CooldownCursorDB.chargeTextAlpha or defaults.chargeTextAlpha)
+    icon.chargeText:SetTextColor(chr, chg, chb, chAlpha)
+
+    local anchorPoint = CHARGE_TEXT_ANCHOR_POINTS[string.upper(CooldownCursorDB.chargeTextAnchor or defaults.chargeTextAnchor)]
+    icon.chargeText:ClearAllPoints()
+    icon.chargeText:SetPoint(anchorPoint.point, icon, anchorPoint.point, anchorPoint.x, anchorPoint.y)
   end
 
   if icon.procOverlay then

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -488,6 +488,11 @@ local function CreateIconFrame(index)
   iconFrame.text:SetPoint("BOTTOM", iconFrame, "TOP", 0, 4)
   iconFrame.text:Hide()
 
+  -- Charge count text (bottom-right corner, like default WoW action bars)
+  iconFrame.chargeText = iconFrame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+  iconFrame.chargeText:SetPoint("BOTTOMRIGHT", iconFrame, "BOTTOMRIGHT", -2, 2)
+  iconFrame.chargeText:Hide()
+
   iconFrame.showAnim = iconFrame:CreateAnimationGroup()
   local scaleUp = iconFrame.showAnim:CreateAnimation("Scale")
   scaleUp:SetOrder(1)
@@ -509,6 +514,7 @@ local function CreateIconFrame(index)
     iconFrame:SetScript("OnUpdate", nil)
     iconFrame.cooldown:Clear()
     iconFrame.text:Hide()
+    iconFrame.chargeText:Hide()
     iconFrame:Hide()
     iconFrame.icon:SetAlpha(1)
     ReturnIconToPool(iconFrame)
@@ -599,6 +605,9 @@ function ReturnIconToPool(iconFrame)
   end
   if iconFrame.primaryLabel then
     iconFrame.primaryLabel:Hide()
+  end
+  if iconFrame.chargeText then
+    iconFrame.chargeText:Hide()
   end
   if iconFrame.procOverlay then
     iconFrame.procOverlay:Hide()
@@ -1249,9 +1258,25 @@ function CooldownCursor:GetPlayerClass()
 end
 
 ----------------------------------------------------
+-- Charge Count Helper
+----------------------------------------------------
+local function UpdateChargeCount(iconFrame, spellID)
+  if not iconFrame or not iconFrame.chargeText then return end
+
+  local chargeInfo = C_Spell.GetSpellCharges(spellID)
+  if chargeInfo then
+    iconFrame.chargeText:SetText(chargeInfo.currentCharges)
+    iconFrame.chargeText:Show()
+  else
+    iconFrame.chargeText:Hide()
+  end
+end
+
+----------------------------------------------------
 -- Icon Setup Helper
 ----------------------------------------------------
 local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
+  print("Setting up new icon for spellID", spellID, "fromProc:", fromProc)
   local iconFrame = GetIconFromPool()
   if not iconFrame then return nil, nil end
 
@@ -1300,6 +1325,10 @@ local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
   iconFrame.icon:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha))
   iconFrame:SetScript("OnUpdate", UpdateCooldownIconFrame)
   iconFrame:Show()
+
+  -- Update charge count display
+  UpdateChargeCount(iconFrame, spellID)
+
   if iconFrame.procOverlay then
     local showProcs = CooldownCursorDB.showProcs ~= false
     local showOverlay = IsProcOverlayEnabled()
@@ -1369,6 +1398,7 @@ local function ShowSpellIcon(spellID, durationObject, fromProc)
           iconFrame.procOutline:Show()
         end
       end
+      UpdateChargeCount(iconFrame, spellID)
       ScheduleHideTimerForIcon(iconFrame, spellID)
       SortIcons()
       UpdateIconPositions()
@@ -2152,6 +2182,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
     if not spellID then return end
 
     if activeIcons[spellID] then
+      UpdateChargeCount(activeIcons[spellID].iconFrame, spellID)
       ApplyShowBehavior()
     end
 
@@ -2168,6 +2199,16 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
       -- Filter out non-cooldown abilities (buffs, mounts, etc.).
       if durationObj and not durationObj:HasSecretValues()
           and durationObj:GetStartTime() == 0 then
+        return
+      end
+
+      -- If spell has charges, show the icon regardless of cooldown state and update charge count
+      local chargeInfo = C_Spell.GetSpellCharges(spellID)
+      if chargeInfo then
+        local iconFrame, iconData = ShowSpellIcon(spellID, durationObj)
+        if iconFrame and iconData then
+          UpdateChargeCount(iconFrame, spellID)
+        end 
         return
       end
 

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -2470,10 +2470,6 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
           return
         end
 
-        -- Check user spell rules
-        local show, rule = CooldownCursor:GetSpellRule(spellID)
-        if not show then return end
-
         if durationObj then
           ShowSpellIcon(spellID, durationObj)
         end

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -489,11 +489,12 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
     ["2.2.0"] = {
       breakingChanges = {
         "Settings have been moved to a 'global' subtable in SavedVariables - existing settings are automatically migrated",
-        "Spell rules are now saved per class - you may need to re-add spells on alt characters",
+        "Spell rules are now saved per class - |cff00ff00you may need to|r |cffFFBB4A/reload|r |cff00ff00UI for alt characters|r",
         _cleanedFlatRulesCheckMsg,
       },
       newFeatures = {
         "Proc Spell Support: Show spell icons when procs are active",
+        "Charge Spell Support: Show spell icons with charges when active",
         "Proc visual indicators with customizable overlay and border",
         "Class-based Spell Rules: Each class now has its own separate spell rules",
         "Spells not known to your current spec are automatically hidden",

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -188,12 +188,12 @@ function CooldownCursor:GetProcOutlineAtlasSettings()
 end
 
 local function IsProcOverlayEnabled()
-  local atlas = CooldownCursorDB.procOverlayAtlas or defaults.procOverlayAtlas
+  local atlas = CooldownCursorDB.global.procOverlayAtlas or defaults.procOverlayAtlas
   return atlas and atlas ~= "" and atlas ~= "none"
 end
 
 local function IsProcOutlineEnabled()
-  local atlas = CooldownCursorDB.procOutlineAtlas or defaults.procOutlineAtlas
+  local atlas = CooldownCursorDB.global.procOutlineAtlas or defaults.procOutlineAtlas
   return atlas and atlas ~= "" and atlas ~= "none"
 end
 
@@ -275,9 +275,16 @@ local defaults = {
 
 function CooldownCursor:ApplyDefaults()
   CooldownCursorDB = CooldownCursorDB or {}
+  CooldownCursorDB.global = CooldownCursorDB.global or {}
   for k, v in pairs(defaults) do
-    if CooldownCursorDB[k] == nil then
-      CooldownCursorDB[k] = v
+    if k == "spellRules" then
+      if CooldownCursorDB.spellRules == nil then
+        CooldownCursorDB.spellRules = v
+      end
+    else
+      if CooldownCursorDB.global[k] == nil then
+        CooldownCursorDB.global[k] = v
+      end
     end
   end
   CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
@@ -305,6 +312,18 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
     end
   end
 
+  -- Migrate top-level settings into .global subtable
+  if not CooldownCursorDB._migrated.movedToGlobal then
+    CooldownCursorDB.global = CooldownCursorDB.global or {}
+    for k, v in pairs(CooldownCursorDB) do
+      if k ~= "global" and k ~= "spellRules" and k ~= "_migrated" then
+        CooldownCursorDB.global[k] = v
+        CooldownCursorDB[k] = nil
+      end
+    end
+    CooldownCursorDB._migrated.movedToGlobal = true
+  end
+
   -- Initialize version if missing
   if not CooldownCursorDB._migrated.version then
     CooldownCursorDB._migrated.version = 0
@@ -325,12 +344,12 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
   -- migration from version 1 to 2 -------------------------------------------------
   if CooldownCursorDB._migrated.version < 2 then
     -- Run breaking changes here
-    if CooldownCursorDB.showWhen == SHOW_WHEN_STATE.ALWAYS then
-      CooldownCursorDB.showWhen = SHOW_WHEN_STATE.COMBAT
+    if CooldownCursorDB.global.showWhen == SHOW_WHEN_STATE.ALWAYS then
+      CooldownCursorDB.global.showWhen = SHOW_WHEN_STATE.COMBAT
     end
 
-    if CooldownCursorDB.anchor ~= ANCHOR_POSITION.TOPRIGHT then
-      CooldownCursorDB.anchor = ANCHOR_POSITION.TOPRIGHT
+    if CooldownCursorDB.global.anchor ~= ANCHOR_POSITION.TOPRIGHT then
+      CooldownCursorDB.global.anchor = ANCHOR_POSITION.TOPRIGHT
     end
   end
   ----------------------------------------------------------------------------------
@@ -402,7 +421,8 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
       end
 
       if migratedCount > 0 then
-        print("|cff00ff00CooldownCursor:|r Migrated " .. migratedCount .. " spell rules to " .. (class or "unknown") .. " format.")
+        print("|cff00ff00CooldownCursor:|r Migrated " ..
+        migratedCount .. " spell rules to " .. (class or "unknown") .. " format.")
       end
     else
       -- No rules exist, mark as done
@@ -420,10 +440,12 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
   -- No code execution, just messages
   -- Notes are organized by version (newest first)
 
-  local _cleanedFlatRulesCheckMsg = CooldownCursorDB._migrated.cleanedFlatRules and "Your migration is marked cleaned" or "Your migration rules are pending cleanup"
+  local _cleanedFlatRulesCheckMsg = CooldownCursorDB._migrated.cleanedFlatRules and "Your migration is marked cleaned" or
+  "Your migration rules are pending cleanup"
   local releaseNotesByVersion = {
     ["2.2.0"] = {
       breakingChanges = {
+        "Settings have been moved to a 'global' subtable in SavedVariables - existing settings are automatically migrated",
         "Spell rules are now saved per class - you may need to re-add spells on alt characters",
         _cleanedFlatRulesCheckMsg,
       },
@@ -603,7 +625,7 @@ local function CreateIconFrame(index)
 
   -- Proc overlay (SPELL_ACTIVATION_OVERLAY_GLOW_SHOW)
   iconFrame.procOverlay = iconFrame:CreateTexture(nil, "OVERLAY")
-  local overlayAtlas = CooldownCursorDB.procOverlayAtlas or defaults.procOverlayAtlas
+  local overlayAtlas = CooldownCursorDB.global.procOverlayAtlas or defaults.procOverlayAtlas
   if IsProcOverlayEnabled() and overlayAtlas and overlayAtlas ~= "" then
     iconFrame.procOverlay:SetAtlas(overlayAtlas, true)
   end
@@ -613,7 +635,7 @@ local function CreateIconFrame(index)
 
   -- Proc outline border
   iconFrame.procOutline = iconFrame:CreateTexture(nil, "OVERLAY")
-  local outlineAtlas = CooldownCursorDB.procOutlineAtlas or defaults.procOutlineAtlas
+  local outlineAtlas = CooldownCursorDB.global.procOutlineAtlas or defaults.procOutlineAtlas
   if IsProcOutlineEnabled() and outlineAtlas and outlineAtlas ~= "" then
     iconFrame.procOutline:SetAtlas(outlineAtlas, true)
   end
@@ -640,7 +662,7 @@ end
 -- Icon Pool Management
 ----------------------------------------------------
 local function InitializeIconPool()
-  local poolSize = CooldownCursorDB.iconPoolSize or defaults.iconPoolSize
+  local poolSize = CooldownCursorDB.global.iconPoolSize or defaults.iconPoolSize
   for i = 1, poolSize do
     local iconFrame = CreateIconFrame(i)
     table.insert(iconPool, iconFrame)
@@ -863,15 +885,15 @@ end
 -- Multi-Icon Stack Offset Calculation
 ----------------------------------------------------
 local function GetStackOffset(index, totalIcons)
-  local iconSize = CooldownCursorDB.iconSize or defaults.iconSize
-  local spacing = CooldownCursorDB.stackSpacing or defaults.stackSpacing
-  local direction = CooldownCursorDB.stackDirection or STACK_DIRECTION.VERTICAL
-  local growth = CooldownCursorDB.stackGrowth or STACK_GROWTH.DOWN
+  local iconSize = CooldownCursorDB.global.iconSize or defaults.iconSize
+  local spacing = CooldownCursorDB.global.stackSpacing or defaults.stackSpacing
+  local direction = CooldownCursorDB.global.stackDirection or STACK_DIRECTION.VERTICAL
+  local growth = CooldownCursorDB.global.stackGrowth or STACK_GROWTH.DOWN
 
   -- For Radius layout
   if direction == STACK_DIRECTION.RADIUS then
-    local radius = CooldownCursorDB.radiusDistance or defaults.radiusDistance
-    local startAngle = CooldownCursorDB.radiusStartAngle or defaults.radiusStartAngle
+    local radius = CooldownCursorDB.global.radiusDistance or defaults.radiusDistance
+    local startAngle = CooldownCursorDB.global.radiusStartAngle or defaults.radiusStartAngle
 
     -- Calculate angle for this icon
     local angleStep = 360 / math.max(1, totalIcons)
@@ -952,9 +974,9 @@ local function UpdateCooldownIconFrame(self)
   local x = cursorX / uiScale
   local y = cursorY / uiScale
 
-  local size = CooldownCursorDB.iconSize or defaults.iconSize
-  local pad = CooldownCursorDB.anchorPadding or defaults.anchorPadding
-  local anchor = CooldownCursorDB.anchor or defaults.anchor
+  local size = CooldownCursorDB.global.iconSize or defaults.iconSize
+  local pad = CooldownCursorDB.global.anchorPadding or defaults.anchorPadding
+  local anchor = CooldownCursorDB.global.anchor or defaults.anchor
 
   local screenW = UIParent:GetWidth()
   local screenH = UIParent:GetHeight()
@@ -1021,11 +1043,11 @@ end
 function CooldownCursor:UpdateSingleIcon(icon, spellID)
   if not icon then return end
 
-  icon.icon:SetShown(not CooldownCursorDB.iconHide)
-  icon.icon:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
+  icon.icon:SetShown(not CooldownCursorDB.global.iconHide)
+  icon.icon:SetAlpha(PercentToAlpha(CooldownCursorDB.global.iconAlpha or defaults.iconAlpha))
 
   icon:SetFrameStrata(
-    FRAME_STRATA[string.upper(CooldownCursorDB.frameStrata)] or
+    FRAME_STRATA[string.upper(CooldownCursorDB.global.frameStrata)] or
     FRAME_STRATA[string.upper(defaults.frameStrata)]
   )
 
@@ -1033,16 +1055,16 @@ function CooldownCursor:UpdateSingleIcon(icon, spellID)
   if icon.cooldownText and not omniCC then
     ApplyFonts(
       icon.cooldownText,
-      CooldownCursorDB.cooldownTextFontPath or defaults.cooldownTextFontPath,
-      CooldownCursorDB.cooldownTextSize or defaults.cooldownTextSize,
-      CooldownCursorDB.cooldownTextFontType or defaults.cooldownTextFontType
+      CooldownCursorDB.global.cooldownTextFontPath or defaults.cooldownTextFontPath,
+      CooldownCursorDB.global.cooldownTextSize or defaults.cooldownTextSize,
+      CooldownCursorDB.global.cooldownTextFontType or defaults.cooldownTextFontType
     )
 
-    local cdr, cdg, cdb = HexToRGB(CooldownCursorDB.cooldownTextColor or defaults.cooldownTextColor)
-    local cdAlpha = PercentToAlpha(CooldownCursorDB.cooldownTextAlpha or defaults.cooldownTextAlpha)
+    local cdr, cdg, cdb = HexToRGB(CooldownCursorDB.global.cooldownTextColor or defaults.cooldownTextColor)
+    local cdAlpha = PercentToAlpha(CooldownCursorDB.global.cooldownTextAlpha or defaults.cooldownTextAlpha)
     icon.cooldownText:SetTextColor(cdr, cdg, cdb, cdAlpha)
 
-    local anchorPoint = CD_TEXT_ANCHOR_POINTS[string.upper(CooldownCursorDB.cooldownTextAnchor)]
+    local anchorPoint = CD_TEXT_ANCHOR_POINTS[string.upper(CooldownCursorDB.global.cooldownTextAnchor)]
         or CD_TEXT_ANCHOR_POINTS[string.upper(defaults.cooldownTextAnchor)]
     icon.cooldownText:ClearAllPoints()
     icon.cooldownText:SetPoint(anchorPoint.point, icon, anchorPoint.point, anchorPoint.x, anchorPoint.y)
@@ -1051,68 +1073,69 @@ function CooldownCursor:UpdateSingleIcon(icon, spellID)
   if icon.text then
     ApplyFonts(
       icon.text,
-      CooldownCursorDB.spellTextFontPath or defaults.spellTextFontPath,
-      CooldownCursorDB.spellTextSize or defaults.spellTextSize,
-      CooldownCursorDB.spellTextFontType or defaults.spellTextFontType
+      CooldownCursorDB.global.spellTextFontPath or defaults.spellTextFontPath,
+      CooldownCursorDB.global.spellTextSize or defaults.spellTextSize,
+      CooldownCursorDB.global.spellTextFontType or defaults.spellTextFontType
     )
 
-    local textr, textg, textb = HexToRGB(CooldownCursorDB.spellTextColor or defaults.spellTextColor)
-    local textAlpha = PercentToAlpha(CooldownCursorDB.spellTextAlpha or defaults.spellTextAlpha)
+    local textr, textg, textb = HexToRGB(CooldownCursorDB.global.spellTextColor or defaults.spellTextColor)
+    local textAlpha = PercentToAlpha(CooldownCursorDB.global.spellTextAlpha or defaults.spellTextAlpha)
     icon.text:SetTextColor(textr, textg, textb, textAlpha)
   end
 
   if icon.chargeText then
     ApplyFonts(
       icon.chargeText,
-      CooldownCursorDB.chargeTextFontPath or defaults.chargeTextFontPath,
-      CooldownCursorDB.chargeTextSize or defaults.chargeTextSize,
-      CooldownCursorDB.chargeTextFontType or defaults.chargeTextFontType
+      CooldownCursorDB.global.chargeTextFontPath or defaults.chargeTextFontPath,
+      CooldownCursorDB.global.chargeTextSize or defaults.chargeTextSize,
+      CooldownCursorDB.global.chargeTextFontType or defaults.chargeTextFontType
     )
 
-    local chr, chg, chb = HexToRGB(CooldownCursorDB.chargeTextColor or defaults.chargeTextColor)
-    local chAlpha = PercentToAlpha(CooldownCursorDB.chargeTextAlpha or defaults.chargeTextAlpha)
+    local chr, chg, chb = HexToRGB(CooldownCursorDB.global.chargeTextColor or defaults.chargeTextColor)
+    local chAlpha = PercentToAlpha(CooldownCursorDB.global.chargeTextAlpha or defaults.chargeTextAlpha)
     icon.chargeText:SetTextColor(chr, chg, chb, chAlpha)
 
-    local anchorPoint = CHARGE_TEXT_ANCHOR_POINTS[string.upper(CooldownCursorDB.chargeTextAnchor or defaults.chargeTextAnchor)]
+    local anchorPoint = CHARGE_TEXT_ANCHOR_POINTS
+    [string.upper(CooldownCursorDB.global.chargeTextAnchor or defaults.chargeTextAnchor)]
     icon.chargeText:ClearAllPoints()
     icon.chargeText:SetPoint(anchorPoint.point, icon, anchorPoint.point, anchorPoint.x, anchorPoint.y)
   end
 
   if icon.procOverlay then
-    local showProcs = CooldownCursorDB.showProcs ~= false
+    local showProcs = CooldownCursorDB.global.showProcs ~= false
     local showOverlay = IsProcOverlayEnabled()
-    local overlayAtlas = CooldownCursorDB.procOverlayAtlas or defaults.procOverlayAtlas
+    local overlayAtlas = CooldownCursorDB.global.procOverlayAtlas or defaults.procOverlayAtlas
     if overlayAtlas and overlayAtlas ~= "" then
       icon.procOverlay:SetAtlas(overlayAtlas, true)
     end
-    local orr, org, orb = HexToRGB(CooldownCursorDB.procOverlayColor or defaults.procOverlayColor)
+    local orr, org, orb = HexToRGB(CooldownCursorDB.global.procOverlayColor or defaults.procOverlayColor)
     icon.procOverlay:SetVertexColor(orr, org, orb, 1)
     icon.procOverlay:SetShown(showProcs and showOverlay and (icon.procActive == true))
   end
   if icon.procOutline then
-    local showProcs = CooldownCursorDB.showProcs ~= false
+    local showProcs = CooldownCursorDB.global.showProcs ~= false
     local showOutline = IsProcOutlineEnabled()
-    local outlineAtlas = CooldownCursorDB.procOutlineAtlas or defaults.procOutlineAtlas
+    local outlineAtlas = CooldownCursorDB.global.procOutlineAtlas or defaults.procOutlineAtlas
     if outlineAtlas and outlineAtlas ~= "" then
       icon.procOutline:SetAtlas(outlineAtlas, true)
     end
-    local otr, otg, otb = HexToRGB(CooldownCursorDB.procOutlineColor or defaults.procOutlineColor)
+    local otr, otg, otb = HexToRGB(CooldownCursorDB.global.procOutlineColor or defaults.procOutlineColor)
     icon.procOutline:SetVertexColor(otr, otg, otb, 1)
     icon.procOutline:SetShown(showProcs and showOutline and (icon.procActive == true))
   end
 
-  local anchorPoint = SPELL_TEXT_ANCHOR_POINTS[string.upper(CooldownCursorDB.spellTextAnchor)]
+  local anchorPoint = SPELL_TEXT_ANCHOR_POINTS[string.upper(CooldownCursorDB.global.spellTextAnchor)]
       or SPELL_TEXT_ANCHOR_POINTS[string.upper(defaults.spellTextAnchor)]
   icon.text:ClearAllPoints()
   icon.text:SetPoint(anchorPoint.point, icon, anchorPoint.relativeTo, anchorPoint.x, anchorPoint.y)
 
   local size = CooldownCursor:GetEffectiveIconSize(spellID)
-  local scale = CooldownCursorDB.scale or defaults.scale
+  local scale = CooldownCursorDB.global.scale or defaults.scale
   icon:SetSize(size * scale, size * scale)
   icon.text:SetScale(scale)
   icon.cooldown:SetScale(scale)
   if icon.procOverlay then
-    local overlayAtlas = CooldownCursorDB.procOverlayAtlas or defaults.procOverlayAtlas
+    local overlayAtlas = CooldownCursorDB.global.procOverlayAtlas or defaults.procOverlayAtlas
     local overlayScale = 1.6
     if overlayAtlas and PROC_OVERLAY_ATLAS_SETTINGS[overlayAtlas] then
       overlayScale = PROC_OVERLAY_ATLAS_SETTINGS[overlayAtlas].scale or overlayScale
@@ -1120,7 +1143,7 @@ function CooldownCursor:UpdateSingleIcon(icon, spellID)
     icon.procOverlay:SetSize(size * scale * overlayScale, size * scale * overlayScale)
   end
   if icon.procOutline then
-    local outlineAtlas = CooldownCursorDB.procOutlineAtlas or defaults.procOutlineAtlas
+    local outlineAtlas = CooldownCursorDB.global.procOutlineAtlas or defaults.procOutlineAtlas
     local outlineScale = 1.9
     if outlineAtlas and PROC_OUTLINE_ATLAS_SETTINGS[outlineAtlas] then
       outlineScale = PROC_OUTLINE_ATLAS_SETTINGS[outlineAtlas].scale or outlineScale
@@ -1128,12 +1151,12 @@ function CooldownCursor:UpdateSingleIcon(icon, spellID)
     icon.procOutline:SetSize(size * scale * outlineScale, size * scale * outlineScale)
   end
 
-  icon.cooldown:SetHideCountdownNumbers(CooldownCursorDB.hideCooldownNumbers)
-  icon.cooldown:SetDrawSwipe(CooldownCursorDB.showCooldownSwipe)
+  icon.cooldown:SetHideCountdownNumbers(CooldownCursorDB.global.hideCooldownNumbers)
+  icon.cooldown:SetDrawSwipe(CooldownCursorDB.global.showCooldownSwipe)
 
   if icon:IsShown() and icon.spellID then
     local info = C_Spell.GetSpellInfo(icon.spellID)
-    if info and CooldownCursorDB.showSpellNames and info.name then
+    if info and CooldownCursorDB.global.showSpellNames and info.name then
       icon.text:SetText(info.name)
       icon.text:Show()
     else
@@ -1145,7 +1168,7 @@ function CooldownCursor:UpdateSingleIcon(icon, spellID)
   -- Apply Masque skin to this icon
   if MasqueGroup then
     MasqueGroup:ReSkin()
-    if CooldownCursorDB.iconHide then
+    if CooldownCursorDB.global.iconHide then
       icon.icon:SetAlpha(0)
     end
   end
@@ -1169,7 +1192,7 @@ local function SortIconsByPriority(a, b)
 end
 
 local function SortIcons()
-  local sortOrder = CooldownCursorDB.sortOrder or SORT_ORDER.PRIORITY
+  local sortOrder = CooldownCursorDB.global.sortOrder or SORT_ORDER.PRIORITY
 
   if sortOrder == SORT_ORDER.ALPHABETICAL then
     table.sort(iconsByPriority, SortIconsAlphabetically)
@@ -1187,8 +1210,8 @@ end
 -- Update Icon Positions
 ----------------------------------------------------
 function UpdateIconPositions()
-  local showBehavior = CooldownCursorDB.showBehavior or SHOW_BEHAVIOR.AUTO_HIDE_AFTER
-  local stackDirection = CooldownCursorDB.stackDirection or defaults.stackDirection
+  local showBehavior = CooldownCursorDB.global.showBehavior or SHOW_BEHAVIOR.AUTO_HIDE_AFTER
+  local stackDirection = CooldownCursorDB.global.stackDirection or defaults.stackDirection
   local isOffCooldown = (showBehavior == SHOW_BEHAVIOR.OFF_COOLDOWN)
 
   -- Radius + OFF_COOLDOWN: don't repack. Radius spaces icons evenly around
@@ -1255,12 +1278,12 @@ local function RemoveIconForSpell(spellID, immediate)
     iconFrame.hideTimer = nil
   end
 
-  if immediate or CooldownCursorDB.fadeOutDuration == 0 then
+  if immediate or CooldownCursorDB.global.fadeOutDuration == 0 then
     ReturnIconToPool(iconFrame)
   else
     iconFrame.fadeOut:Stop()
     local fadeOutAnim = iconFrame.fadeOut:GetAnimations()
-    fadeOutAnim:SetDuration(CooldownCursorDB.fadeOutDuration or 0.3)
+    fadeOutAnim:SetDuration(CooldownCursorDB.global.fadeOutDuration or 0.3)
     iconFrame.fadeOut:Play()
   end
 
@@ -1280,7 +1303,7 @@ local function ScheduleHideTimerForIcon(iconFrame, spellID)
   -- Hide timer only applies to AUTO_HIDE_AFTER mode.
   -- ON_COOLDOWN removes icons itself when cooldown ends.
   -- OFF_COOLDOWN keeps icons alive permanently so it can show/hide them.
-  local showBehavior = CooldownCursorDB.showBehavior or SHOW_BEHAVIOR.AUTO_HIDE_AFTER
+  local showBehavior = CooldownCursorDB.global.showBehavior or SHOW_BEHAVIOR.AUTO_HIDE_AFTER
   if showBehavior ~= SHOW_BEHAVIOR.AUTO_HIDE_AFTER then
     return
   end
@@ -1289,7 +1312,7 @@ local function ScheduleHideTimerForIcon(iconFrame, spellID)
     iconFrame.hideTimer:Cancel()
   end
 
-  local hideAfter = CooldownCursorDB.hideAfter or defaults.hideAfter
+  local hideAfter = CooldownCursorDB.global.hideAfter or defaults.hideAfter
 
   iconFrame.hideTimer = C_Timer.NewTimer(hideAfter, function()
     RemoveIconForSpell(spellID, false)
@@ -1300,7 +1323,7 @@ end
 -- Enforce Max Icons
 ----------------------------------------------------
 local function EnforceMaxIcons()
-  local maxIcons = CooldownCursorDB.maxIcons or defaults.maxIcons
+  local maxIcons = CooldownCursorDB.global.maxIcons or defaults.maxIcons
 
   while #iconsByPriority > maxIcons do
     local toRemove = iconsByPriority[#iconsByPriority]
@@ -1375,7 +1398,7 @@ end
 local function UpdateChargeCount(iconFrame, spellID)
   if not iconFrame or not iconFrame.chargeText then return end
 
-  if CooldownCursorDB.showCharges == false then
+  if CooldownCursorDB.global.showCharges == false then
     iconFrame.chargeText:Hide()
     return
   end
@@ -1430,20 +1453,20 @@ local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
   iconFrame.icon:SetTexture(spellInfo.iconID)
   iconFrame.cooldown:SetCooldownFromDurationObject(durationObject)
 
-  if CooldownCursorDB.showSpellNames and spellInfo.name then
+  if CooldownCursorDB.global.showSpellNames and spellInfo.name then
     iconFrame.text:SetText(spellInfo.name)
     iconFrame.text:Show()
   else
     iconFrame.text:Hide()
   end
 
-  if CooldownCursorDB.animation then
+  if CooldownCursorDB.global.animation then
     iconFrame:SetScale(1)
     iconFrame.showAnim:Stop()
     iconFrame.showAnim:Play()
   end
 
-  iconFrame.icon:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha))
+  iconFrame.icon:SetAlpha(PercentToAlpha(CooldownCursorDB.global.iconAlpha))
   iconFrame:SetScript("OnUpdate", UpdateCooldownIconFrame)
   iconFrame:Show()
 
@@ -1451,12 +1474,12 @@ local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
   UpdateChargeCount(iconFrame, spellID)
 
   if iconFrame.procOverlay then
-    local showProcs = CooldownCursorDB.showProcs ~= false
+    local showProcs = CooldownCursorDB.global.showProcs ~= false
     local showOverlay = IsProcOverlayEnabled()
     iconFrame.procOverlay:SetShown(showProcs and showOverlay and procActive)
   end
   if iconFrame.procOutline then
-    local showProcs = CooldownCursorDB.showProcs ~= false
+    local showProcs = CooldownCursorDB.global.showProcs ~= false
     local showOutline = IsProcOutlineEnabled()
     iconFrame.procOutline:SetShown(showProcs and showOutline and procActive)
   end
@@ -1469,14 +1492,14 @@ end
 ----------------------------------------------------
 local function ShowSpellIcon(spellID, durationObject, fromProc)
   -- Don't create icons if addon is disabled
-  if CooldownCursorDB.enabled == false then
+  if CooldownCursorDB.global.enabled == false then
     return nil, nil
   end
 
   local spellInfo = C_Spell.GetSpellInfo(spellID)
   if not spellInfo or not spellInfo.iconID then return nil, nil end
 
-  local stackDirection = CooldownCursorDB.stackDirection or defaults.stackDirection
+  local stackDirection = CooldownCursorDB.global.stackDirection or defaults.stackDirection
   local isSingleMode = (stackDirection == STACK_DIRECTION.SINGLE)
 
   if isSingleMode then
@@ -1505,7 +1528,7 @@ local function ShowSpellIcon(spellID, durationObject, fromProc)
         existingIcon.procOnly = false
         iconFrame.procOnly = false
       end
-      if activeProcSpells[spellID] and CooldownCursorDB.showProcs ~= false then
+      if activeProcSpells[spellID] and CooldownCursorDB.global.showProcs ~= false then
         existingIcon.procActive = true
         iconFrame.procActive = true
         if iconFrame.procOverlay then
@@ -1549,22 +1572,22 @@ local function ApplyShowBehavior()
   if previewActive then return end
 
   -- Don't do anything if addon is disabled
-  if CooldownCursorDB.enabled == false then
+  if CooldownCursorDB.global.enabled == false then
     return
   end
 
-  local showBehavior = CooldownCursorDB.showBehavior or SHOW_BEHAVIOR.AUTO_HIDE_AFTER
+  local showBehavior = CooldownCursorDB.global.showBehavior or SHOW_BEHAVIOR.AUTO_HIDE_AFTER
 
   -- AUTO_HIDE_AFTER - nothing extra to do here
   if showBehavior == SHOW_BEHAVIOR.AUTO_HIDE_AFTER then
     -- If a spell can proc, only show it while the proc is active
-    if CooldownCursorDB.showProcs ~= false then
+    if CooldownCursorDB.global.showProcs ~= false then
       for spellID, iconData in pairs(activeIcons) do
         local iconFrame = iconData.iconFrame
         if iconFrame and procCapableSpells[spellID] then
           local isProcActive = iconData.procActive or iconFrame.procActive
           if isProcActive then
-            iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
+            iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.global.iconAlpha or defaults.iconAlpha))
           else
             iconFrame:SetAlpha(0)
           end
@@ -1583,7 +1606,7 @@ local function ApplyShowBehavior()
     if classRules then
       for spellID, rule in pairs(classRules) do
         -- If spell has no cooldown and user doesn't want to show procs, skip it
-        if not CooldownCursorDB.showProcs and GetSpellBaseCooldown(spellID) == 0 then
+        if not CooldownCursorDB.global.showProcs and GetSpellBaseCooldown(spellID) == 0 then
           -- continue to next spell (can't use continue in Lua, so we use a nested if)
         elseif rule.enabled ~= false and not activeIcons[spellID] and C_SpellBook.IsSpellKnown(spellID) then
           local durationObject = C_Spell.GetSpellCooldownDuration(spellID)
@@ -1604,14 +1627,14 @@ local function ApplyShowBehavior()
     local iconFrame = iconData.iconFrame
     if iconFrame then
       local isOnCooldown = iconFrame.cooldown:IsShown()
-      local isProcActive = (CooldownCursorDB.showProcs ~= false) and (iconData.procActive or iconFrame.procActive)
+      local isProcActive = (CooldownCursorDB.global.showProcs ~= false) and (iconData.procActive or iconFrame.procActive)
 
       -- Update charge count text
       UpdateChargeCount(iconFrame, spellID)
 
       -- Reset alpha in case it was modified in OFF_COOLDOWN mode
       if isOnCooldown or isProcActive then
-        iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
+        iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.global.iconAlpha or defaults.iconAlpha))
       end
 
       if showBehavior == SHOW_BEHAVIOR.ON_COOLDOWN then
@@ -1626,21 +1649,21 @@ local function ApplyShowBehavior()
         local procOnlySpell = procCapableSpells[spellID] and GetSpellBaseCooldown(spellID) == 0
         if isProcActive then
           -- Proc is active - always show
-          iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
-        elseif procOnlySpell and (CooldownCursorDB.showProcs ~= false) then
+          iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.global.iconAlpha or defaults.iconAlpha))
+        elseif procOnlySpell and (CooldownCursorDB.global.showProcs ~= false) then
           -- Proc-only spell (no cooldown) not currently proccing - hide
           iconFrame:SetAlpha(0)
         elseif isOnCooldown then
           -- On cooldown - but if spell has charges available, still show it
-          local chargeInfo = CooldownCursorDB.showCharges ~= false and C_Spell.GetSpellCharges(spellID)
+          local chargeInfo = CooldownCursorDB.global.showCharges ~= false and C_Spell.GetSpellCharges(spellID)
           if chargeInfo and chargeInfo.currentCharges then
-            iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
+            iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.global.iconAlpha or defaults.iconAlpha))
           else
             iconFrame:SetAlpha(0)
           end
         else
           -- Off cooldown and ready - show
-          iconFrame:SetAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha)
+          iconFrame:SetAlpha(CooldownCursorDB.global.iconAlpha or defaults.iconAlpha)
         end
       end
     end
@@ -1672,7 +1695,7 @@ function CooldownCursor:HideIconNow()
     if #iconsByPriority > 0 then
       local iconFrame = iconsByPriority[1].iconFrame
       if iconFrame then
-        RemoveIconForSpell(iconsByPriority[1].spellID, CooldownCursorDB.fadeOutDuration == 0)
+        RemoveIconForSpell(iconsByPriority[1].spellID, CooldownCursorDB.global.fadeOutDuration == 0)
       end
     end
     lastSpellId = nil
@@ -1715,19 +1738,19 @@ function CooldownCursor:GetNotes()
 end
 
 function CooldownCursor:GetDBValue(key)
-  if CooldownCursorDB[key] ~= nil then
-    return CooldownCursorDB[key]
+  if CooldownCursorDB.global[key] ~= nil then
+    return CooldownCursorDB.global[key]
   end
   return defaults[key]
 end
 
 function CooldownCursor:SetDBString(key, value)
-  CooldownCursorDB[key] = string.format("%s", value)
+  CooldownCursorDB.global[key] = string.format("%s", value)
   self:UpdateDisplay()
 end
 
 function CooldownCursor:SetDBNumber(key, value)
-  CooldownCursorDB[key] = tonumber(value)
+  CooldownCursorDB.global[key] = tonumber(value)
   -- Switching showBehavior leaves stale icons (wrong alphas, wrong set of
   -- icons tracked). Clear everything and let ApplyShowBehavior re-seed.
   if key == "showBehavior" then
@@ -1747,7 +1770,7 @@ function CooldownCursor:SetDBNumber(key, value)
 end
 
 function CooldownCursor:SetDBBoolean(key, value)
-  CooldownCursorDB[key] = value and true or false
+  CooldownCursorDB.global[key] = value and true or false
   self:UpdateDisplay()
 end
 
@@ -1845,8 +1868,8 @@ function CooldownCursor:GetEffectiveIconSize(spellID)
 end
 
 function CooldownCursor:SetFontPath(key, value)
-  CooldownCursorDB[key] = value
-  CooldownCursorDB[key .. "Path"] = FontPath(CooldownCursorDB[key])
+  CooldownCursorDB.global[key] = value
+  CooldownCursorDB.global[key .. "Path"] = FontPath(CooldownCursorDB.global[key])
   self:UpdateDisplay()
 end
 
@@ -1898,11 +1921,11 @@ function CooldownCursor:GetValidFrameStrata(strata)
 end
 
 function CooldownCursor:SetHideAfter(seconds)
-  CooldownCursorDB.hideAfter = tonumber(seconds) or defaults.hideAfter
+  CooldownCursorDB.global.hideAfter = tonumber(seconds) or defaults.hideAfter
 end
 
 function CooldownCursor:SetFadeOutDuration(seconds)
-  CooldownCursorDB.fadeOutDuration = tonumber(seconds) or defaults.fadeOutDuration
+  CooldownCursorDB.global.fadeOutDuration = tonumber(seconds) or defaults.fadeOutDuration
 end
 
 function CooldownCursor:GetPreviewMouseMode()
@@ -1917,15 +1940,11 @@ function CooldownCursor:SetPreviewMouseMode(enabled)
 end
 
 function CooldownCursor:ResetSettings()
-  local rules = CooldownCursorDB.spellRules
-  local _migrated = CooldownCursorDB._migrated
   CooldownCursor:HideIconNow()
-  CooldownCursorDB = {}
+  CooldownCursorDB.global = {}
   self:ApplyDefaults()
   self:UpdateDisplay()
   CooldownCursor:SetPreviewMouseMode(true)
-  CooldownCursorDB.spellRules = rules
-  CooldownCursorDB._migrated = _migrated
 end
 
 ----------------------------------------------------
@@ -1945,7 +1964,7 @@ function CooldownCursor:GetActiveIconCount()
 end
 
 function CooldownCursor:IsMultiIconEnabled()
-  local stackDirection = CooldownCursorDB.stackDirection or defaults.stackDirection
+  local stackDirection = CooldownCursorDB.global.stackDirection or defaults.stackDirection
   return stackDirection ~= STACK_DIRECTION.SINGLE
 end
 
@@ -1982,7 +2001,7 @@ function CooldownCursor:GetValidStackDirections()
 end
 
 function CooldownCursor:GetValidStackGrowth()
-  local direction = CooldownCursorDB.stackDirection or STACK_DIRECTION.VERTICAL
+  local direction = CooldownCursorDB.global.stackDirection or STACK_DIRECTION.VERTICAL
 
   if direction == STACK_DIRECTION.SINGLE then
     return {
@@ -2043,7 +2062,7 @@ function CooldownCursor:Preview()
 
   local function ApplyPreviewProc(iconFrame, iconData)
     if not iconFrame or not iconData then return end
-    if CooldownCursorDB.showProcs == false then return end
+    if CooldownCursorDB.global.showProcs == false then return end
     iconData.procActive = true
     iconFrame.procActive = true
     if iconFrame.procOverlay then
@@ -2132,7 +2151,7 @@ function CooldownCursor:PreviewMultiIcon()
 
   local function ApplyPreviewProc(iconFrame, iconData)
     if not iconFrame or not iconData then return end
-    if CooldownCursorDB.showProcs == false then return end
+    if CooldownCursorDB.global.showProcs == false then return end
     iconData.procActive = true
     iconFrame.procActive = true
     if iconFrame.procOverlay then
@@ -2172,7 +2191,7 @@ end
 function CooldownCursor:ApplyPreviewPosition()
   if not previewActive then return end
 
-  local isRadius = (CooldownCursorDB.stackDirection or defaults.stackDirection) == "RADIUS"
+  local isRadius = (CooldownCursorDB.global.stackDirection or defaults.stackDirection) == "RADIUS"
 
   if previewMouseMode then
     for i, iconData in ipairs(iconsByPriority) do
@@ -2239,7 +2258,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
   if event == "SPELL_ACTIVATION_OVERLAY_GLOW_SHOW" then
     local spellID = ...
     if not spellID then return end
-    if CooldownCursorDB.showProcs == false then return end
+    if CooldownCursorDB.global.showProcs == false then return end
 
     local show = CooldownCursor:GetSpellRule(spellID)
     if not show then return end
@@ -2272,7 +2291,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
   if event == "SPELL_ACTIVATION_OVERLAY_GLOW_HIDE" then
     local spellID = ...
     if not spellID then return end
-    if CooldownCursorDB.showProcs == false then return end
+    if CooldownCursorDB.global.showProcs == false then return end
     activeProcSpells[spellID] = nil
     local iconData = activeIcons[spellID]
     if iconData and iconData.iconFrame then
@@ -2295,7 +2314,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
   if event == "PLAYER_REGEN_DISABLED" then
     -- Entering combat
     inCombat = true
-    if CooldownCursorDB.showWhen == SHOW_WHEN_STATE.NON_COMBAT then
+    if CooldownCursorDB.global.showWhen == SHOW_WHEN_STATE.NON_COMBAT then
       CooldownCursor:HideIconNow()
     else
       ApplyShowBehavior()
@@ -2306,7 +2325,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
   if event == "PLAYER_REGEN_ENABLED" then
     -- Exiting combat
     inCombat = false
-    if CooldownCursorDB.showWhen == SHOW_WHEN_STATE.COMBAT then
+    if CooldownCursorDB.global.showWhen == SHOW_WHEN_STATE.COMBAT then
       CooldownCursor:HideIconNow()
     else
       ApplyShowBehavior()
@@ -2314,15 +2333,15 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
     return
   end
 
-  if CooldownCursorDB.showWhen == SHOW_WHEN_STATE.NON_COMBAT and inCombat then
+  if CooldownCursorDB.global.showWhen == SHOW_WHEN_STATE.NON_COMBAT and inCombat then
     return
   end
 
-  if CooldownCursorDB.showWhen == SHOW_WHEN_STATE.COMBAT and not inCombat then
+  if CooldownCursorDB.global.showWhen == SHOW_WHEN_STATE.COMBAT and not inCombat then
     return
   end
 
-  if CooldownCursorDB.hideWhileMounted and IsMounted() then
+  if CooldownCursorDB.global.hideWhileMounted and IsMounted() then
     return
   end
 
@@ -2334,7 +2353,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
   if SPELL_EVENTS[event] then
     local spellID
     -- Check if addon is enabled
-    if CooldownCursorDB.enabled == false then
+    if CooldownCursorDB.global.enabled == false then
       return
     end
 
@@ -2370,7 +2389,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
 
       -- Check spell usability
       if inRange == false and
-          CooldownCursorDB.showBehavior ~= SHOW_BEHAVIOR.OFF_COOLDOWN then
+          CooldownCursorDB.global.showBehavior ~= SHOW_BEHAVIOR.OFF_COOLDOWN then
         return
       end
 
@@ -2404,5 +2423,3 @@ CooldownCursor:RegisterEvent("PLAYER_REGEN_ENABLED")
 CooldownCursor:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_SHOW")
 CooldownCursor:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_HIDE")
 CooldownCursor:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
-
-

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -1494,6 +1494,7 @@ local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
     priority = priority,
     procActive = procActive,
     procOnly = fromProc == true,
+    baseCooldown = metadata.baseCooldown or 0,
   }
 
   activeIcons[spellID] = iconData
@@ -1663,7 +1664,7 @@ local function ApplyShowBehavior()
     if classRules then
       for spellID, rule in pairs(classRules) do
         -- If spell has no cooldown and user doesn't want to show procs, skip it
-        if not CooldownCursorDB.global.showProcs and GetSpellBaseCooldown(spellID) == 0 then
+        if not CooldownCursorDB.global.showProcs and rule.metadata.baseCooldown == 0 then
           -- continue to next spell (can't use continue in Lua, so we use a nested if)
         elseif (rule.settings and rule.settings.enabled ~= false) and not activeIcons[spellID] and C_SpellBook.IsSpellKnown(spellID) then
           local durationObject = C_Spell.GetSpellCooldownDuration(spellID)
@@ -1705,7 +1706,7 @@ local function ApplyShowBehavior()
       elseif showBehavior == SHOW_BEHAVIOR.OFF_COOLDOWN then
         -- OFF_COOLDOWN: icon should only be visible when ready.
         -- Use SetAlpha so the cooldown frame stays alive and keeps updating.
-        local procOnlySpell = procCapableSpells[spellID] and GetSpellBaseCooldown(spellID) == 0
+        local procOnlySpell = procCapableSpells[spellID] and iconData.baseCooldown == 0
         if isProcActive then
           -- Proc is active - always show
           iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.global.iconAlpha or defaults.iconAlpha))

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -371,6 +371,14 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
     ["2.2.0"] = {
       breakingChanges = {
         "Spell rules are now saved per class - you may need to re-add spells on alt characters",
+      },
+      newFeatures = {
+        "Proc Spell Support: Show spell icons when procs are active",
+        "Proc visual indicators with customizable overlay and border",
+        "Class-based Spell Rules: Each class now has its own separate spell rules",
+        "Spells not known to your current spec are automatically hidden",
+      },
+    },
     ["2.1.3"] = {
       fixes = {
         "Fixed spell icons not showing when 'Show When' is set to 'Out of Combat' or 'Always'",
@@ -382,13 +390,6 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
       fixes = {
         "Minor bug fixes",
       },
-      newFeatures = {
-        "Proc Spell Support: Show spell icons when procs are active",
-        "Proc visual indicators with customizable overlay and border",
-        "Class-based Spell Rules: Each class now has its own separate spell rules",
-        "Spells not known to your current spec are automatically hidden",
-      },
-      fixes = {},
     },
     ["2.1.0"] = {
       breakingChanges = {

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -2250,7 +2250,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
     unit = ...
     if unit == "player" then
       CooldownCursor:HideAllIcons(true)
-      CooldownCursor:ApplyShowBehavior()
+      ApplyShowBehavior()
       return
     end
   end

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -354,6 +354,22 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
             if not rules[class][spellID] then
               rules[class][spellID] = ruleData
             end
+
+            -- Populate static spell metadata
+            local rule = rules[class][spellID]
+            local baseCooldownMS, _ = GetSpellBaseCooldown(spellID)
+            local baseCooldown = baseCooldownMS and (baseCooldownMS / 1000) or 0
+            local chargeInfo = C_Spell.GetSpellCharges(spellID)
+            local info = C_Spell.GetSpellInfo(spellID)
+            rule.baseCooldown = baseCooldown
+            rule.hasCooldown = baseCooldown > 1.5
+            rule.hasCharges = chargeInfo ~= nil
+            rule.maxCharges = chargeInfo and chargeInfo.maxCharges or nil
+            rule.isInstantCast = info and info.castTime == 0 or false
+            rule.castTime = info and (info.castTime / 1000) or 0
+            rule.hasRange = info and info.maxRange > 0 or false
+            rule.maxRange = info and info.maxRange or 0
+
             rules[spellID] = nil -- Remove from old format
             migratedCount = migratedCount + 1
           else
@@ -387,10 +403,12 @@ function CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
   -- No code execution, just messages
   -- Notes are organized by version (newest first)
 
+  local _cleanedFlatRulesCheckMsg = CooldownCursorDB._cleanedFlatRules and "Your migration is marked cleaned" or "Your migration rules are pending cleanup"
   local releaseNotesByVersion = {
     ["2.2.0"] = {
       breakingChanges = {
         "Spell rules are now saved per class - you may need to re-add spells on alt characters",
+        _cleanedFlatRulesCheckMsg,
       },
       newFeatures = {
         "Proc Spell Support: Show spell icons when procs are active",

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -1495,6 +1495,7 @@ local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
     procActive = procActive,
     procOnly = fromProc == true,
     baseCooldown = metadata.baseCooldown or 0,
+    hasCharges = metadata.hasCharges or false,
   }
 
   activeIcons[spellID] = iconData
@@ -1688,8 +1689,10 @@ local function ApplyShowBehavior()
       local isOnCooldown = iconFrame.cooldown:IsShown()
       local isProcActive = (CooldownCursorDB.global.showProcs ~= false) and (iconData.procActive or iconFrame.procActive)
 
-      -- Update charge count text
-      UpdateChargeCount(iconFrame, spellID)
+      -- Update charge count text (only for spells that have charges)
+      if iconData.hasCharges then
+        UpdateChargeCount(iconFrame, spellID)
+      end
 
       -- Reset alpha in case it was modified in OFF_COOLDOWN mode
       if isOnCooldown or isProcActive then
@@ -2440,8 +2443,9 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
     if not spellID then return end
 
     -- Check user spell rules before doing any cooldown queries
-    local show, _ = CooldownCursor:GetSpellRule(spellID)
+    local show, rule = CooldownCursor:GetSpellRule(spellID)
     if not show then return end
+    local hasCharges = rule and rule.metadata and rule.metadata.hasCharges or false
 
     -- Debounce: skip if a timer is already pending for this spellID
     if not pendingSpellTimers[spellID] then
@@ -2450,7 +2454,6 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
       C_Timer.After(0.01, function()
         pendingSpellTimers[spellID] = nil
         local durationObj = C_Spell.GetSpellCooldownDuration(spellID)
-        local hasCharges = C_Spell.GetSpellCharges(spellID) ~= nil
 
         if not durationObj then return end
 

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -905,10 +905,9 @@ end
 ----------------------------------------------------
 local function UpdateCooldownIconFrame(self)
   if IsAnyPanelOpen() and not previewActive then
-    self.icon:Hide()
+    self:ClearAllPoints()
+    self:SetPoint("CENTER", UIParent, "BOTTOMLEFT", -100, -100) -- Move off-screen when any panel is open
     return
-  else
-    self.icon:SetShown(not CooldownCursorDB.iconHide)
   end
 
   local uiScale = UIParent:GetEffectiveScale()

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -2203,14 +2203,17 @@ function CooldownCursor:PreviewMultiIcon()
       -- Use spells from user's class-specific spell rules
       for spellID, rule in pairs(classRules) do
         local ruleSettings = rule.settings or {}
+        local metadata = rule.metadata or {}
         if ruleSettings.enabled ~= false and IsSpellKnownCached(spellID) then
           local info = C_Spell.GetSpellInfo(spellID)
           if info then
+            local isProc = not metadata.hasCooldown and not metadata.hasCharges
             table.insert(previewSpells, {
               id = spellID,
               duration = 30 + (#previewSpells * 5), -- Vary durations
               name = info.name,
               priority = ruleSettings.priority or 0,
+              isProc = isProc,
             })
           end
         end
@@ -2259,8 +2262,10 @@ function CooldownCursor:PreviewMultiIcon()
       local spellData = spellPool[i]
       local durationObj = C_DurationUtil.CreateDuration()
       durationObj:SetTimeFromStart(GetTime(), spellData.duration)
-      local iconFrame, iconData = ShowSpellIcon(spellData.id, durationObj)
-      ApplyPreviewProc(iconFrame, iconData)
+      local iconFrame, iconData = ShowSpellIcon(spellData.id, durationObj, spellData.isProc)
+      if spellData.isProc then
+        ApplyPreviewProc(iconFrame, iconData)
+      end
     end
     self:ApplyPreviewPosition()
   end

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -53,6 +53,18 @@ local previewMouseMode = true
 local activeProcSpells = {}
 local procCapableSpells = {}
 
+-- Cached known-spell lookup (invalidated on spec change)
+local knownSpellCache = {}
+
+local function IsSpellKnownCached(spellID)
+  local cached = knownSpellCache[spellID]
+  if cached == nil then
+    cached = C_SpellBook.IsSpellKnown(spellID)
+    knownSpellCache[spellID] = cached
+  end
+  return cached
+end
+
 -- Cached screen metrics (refreshed on scale/resolution changes)
 local cachedUIScale = 1
 local cachedScreenW = 0
@@ -1435,7 +1447,7 @@ function CooldownCursor:GetSpellRule(spellID)
   if not rule then return false end
 
   -- If spell is not known to the player (wrong spec, etc.), don't show it
-  if not C_SpellBook.IsSpellKnown(spellID) then return false end
+  if not IsSpellKnownCached(spellID) then return false end
 
   -- Return whether the spell is enabled
   local settings = rule.settings or {}
@@ -1667,7 +1679,7 @@ local function ApplyShowBehavior()
         -- If spell has no cooldown and user doesn't want to show procs, skip it
         if not CooldownCursorDB.global.showProcs and rule.metadata.baseCooldown == 0 then
           -- continue to next spell (can't use continue in Lua, so we use a nested if)
-        elseif (rule.settings and rule.settings.enabled ~= false) and not activeIcons[spellID] and C_SpellBook.IsSpellKnown(spellID) then
+        elseif (rule.settings and rule.settings.enabled ~= false) and not activeIcons[spellID] and IsSpellKnownCached(spellID) then
           local durationObject = C_Spell.GetSpellCooldownDuration(spellID)
           if durationObject then
             ShowSpellIcon(spellID, durationObject)
@@ -2190,7 +2202,7 @@ function CooldownCursor:PreviewMultiIcon()
       -- Use spells from user's class-specific spell rules
       for spellID, rule in pairs(classRules) do
         local ruleSettings = rule.settings or {}
-        if ruleSettings.enabled ~= false and C_SpellBook.IsSpellKnown(spellID) then
+        if ruleSettings.enabled ~= false and IsSpellKnownCached(spellID) then
           local info = C_Spell.GetSpellInfo(spellID)
           if info then
             table.insert(previewSpells, {
@@ -2319,6 +2331,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
   if event == "PLAYER_SPECIALIZATION_CHANGED" then
     unit = ...
     if unit == "player" then
+      knownSpellCache = {}
       CooldownCursor:HideAllIcons(true)
       ApplyShowBehavior()
       return

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -2193,6 +2193,15 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
     return
   end
 
+  if event == "PLAYER_SPECIALIZATION_CHANGED" then
+    unit = ...
+    if unit == "player" then
+      CooldownCursor:HideAllIcons(true)
+      CooldownCursor:ApplyShowBehavior()
+      return
+    end
+  end
+
   if event == "SPELL_ACTIVATION_OVERLAY_GLOW_SHOW" then
     local spellID = ...
     if not spellID then return end
@@ -2360,5 +2369,6 @@ CooldownCursor:RegisterEvent("PLAYER_REGEN_DISABLED")
 CooldownCursor:RegisterEvent("PLAYER_REGEN_ENABLED")
 CooldownCursor:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_SHOW")
 CooldownCursor:RegisterEvent("SPELL_ACTIVATION_OVERLAY_GLOW_HIDE")
+CooldownCursor:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 
 

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -1466,13 +1466,18 @@ local function ApplyShowBehavior()
       elseif showBehavior == SHOW_BEHAVIOR.OFF_COOLDOWN then
         -- OFF_COOLDOWN: icon should only be visible when ready.
         -- Use SetAlpha so the cooldown frame stays alive and keeps updating.
-        if (CooldownCursorDB.showProcs ~= false) and procCapableSpells[spellID] and not isProcActive then
-          iconFrame:SetAlpha(0)
-        elseif isProcActive then
+        local procOnlySpell = procCapableSpells[spellID] and GetSpellBaseCooldown(spellID) == 0
+        if isProcActive then
+          -- Proc is active - always show
           iconFrame:SetAlpha(PercentToAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha))
+        elseif procOnlySpell and (CooldownCursorDB.showProcs ~= false) then
+          -- Proc-only spell (no cooldown) not currently proccing - hide
+          iconFrame:SetAlpha(0)
         elseif isOnCooldown then
+          -- On cooldown - hide
           iconFrame:SetAlpha(0)
         else
+          -- Off cooldown and ready - show
           iconFrame:SetAlpha(CooldownCursorDB.iconAlpha or defaults.iconAlpha)
         end
       end
@@ -2037,7 +2042,7 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
     local spellID = ...
     if not spellID then return end
     if CooldownCursorDB.showProcs == false then return end
-    if not IsPlayerSpell(spellID) then return end
+
     local show = CooldownCursor:GetSpellRule(spellID)
     if not show then return end
     activeProcSpells[spellID] = true
@@ -2150,6 +2155,10 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
       ApplyShowBehavior()
     end
 
+    -- Check user spell rules before doing any cooldown queries
+    local show, _ = CooldownCursor:GetSpellRule(spellID)
+    if not show then return end
+
     -- Delay slightly to allow cooldown to register
     C_Timer.After(0.01, function()
       local durationObj = C_Spell.GetSpellCooldownDuration(spellID)
@@ -2162,9 +2171,6 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
         return
       end
 
-      -- Check spells are known to player
-      if not IsPlayerSpell(spellID) then return end
-
       -- local usable = C_Spell.IsSpellUsable(spellID)
       local inRange = C_Spell.IsSpellInRange(spellID)
 
@@ -2174,13 +2180,12 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
         return
       end
 
-      -- Check user spell rules
-      local show, rule = CooldownCursor:GetSpellRule(spellID)
-      if not show then return end
-
-      -- If spell has no cooldown and user doesn't want to show procs, skip it
-      if not CooldownCursorDB.showProcs and GetSpellBaseCooldown(spellID) == 0 then
-        return
+      -- If spell has no base cooldown, it's a proc spell
+      -- Only show it if procs are enabled AND the spell is currently proccing
+      if GetSpellBaseCooldown(spellID) == 0 then
+        if not CooldownCursorDB.showProcs or not activeProcSpells[spellID] then
+          return
+        end
       end
       if durationObj then
         ShowSpellIcon(spellID, durationObj)

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -1366,6 +1366,11 @@ local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
   local priority = (rule and rule.priority) or 0
   local procActive = activeProcSpells[spellID] or false
 
+  -- If this spell is an instant cast or has no cooldown, and it's not from a proc, don't create icon.
+  if not fromProc and rule and not rule.hasCooldown and not rule.hasCharges then
+    return
+  end
+
   local iconData = {
     spellID = spellID,
     iconFrame = iconFrame,
@@ -2331,14 +2336,6 @@ CooldownCursor:SetScript("OnEvent", function(self, event, ...)
         UpdateChargeCount(iconFrame, spellID)
         ApplyShowBehavior()
         return
-      end
-
-      -- If spell has no base cooldown, it's a proc spell
-      -- Only show it if procs are enabled AND the spell is currently proccing
-      if GetSpellBaseCooldown(spellID) == 0 then
-        if not CooldownCursorDB.showProcs or not activeProcSpells[spellID] then
-          return
-        end
       end
 
       if durationObj then

--- a/CooldownCursor.lua
+++ b/CooldownCursor.lua
@@ -507,8 +507,8 @@ local function CreateIconFrame(index)
   iconFrame.text:SetPoint("BOTTOM", iconFrame, "TOP", 0, 4)
   iconFrame.text:Hide()
 
-  -- Charge count text
-  iconFrame.chargeText = iconFrame:CreateFontString(nil, "OVERLAY")
+  -- Charge count text (parented to cooldown frame so it draws above the swipe)
+  iconFrame.chargeText = iconFrame.cooldown:CreateFontString(nil, "OVERLAY")
   iconFrame.chargeText:Hide()
 
   iconFrame.showAnim = iconFrame:CreateAnimationGroup()

--- a/CooldownCursor.toc
+++ b/CooldownCursor.toc
@@ -12,4 +12,3 @@ Spells.lua
 CooldownCursor.lua
 Options.lua
 Slash.lua
-

--- a/CooldownCursor.toc
+++ b/CooldownCursor.toc
@@ -2,7 +2,7 @@
 ## Title: CooldownCursor
 ## Notes: Shows cooldown timers at your cursor position
 ## Author: jrosco
-## Version: 2.1.1
+## Version: 2.2.0
 ## SavedVariables: CooldownCursorDB
 ## OptionalDeps: Masque
 

--- a/Options.lua
+++ b/Options.lua
@@ -87,8 +87,8 @@ function CooldownCursor:RebuildSpellRuleOptions()
 
   -- Sort by priority (higher first), then alphabetically for priority 0
   table.sort(sorted, function(a, b)
-    local aPriority = a.rule.priority or 0
-    local bPriority = b.rule.priority or 0
+    local aPriority = (a.rule.settings and a.rule.settings.priority) or 0
+    local bPriority = (b.rule.settings and b.rule.settings.priority) or 0
 
     -- Spells with priority > 0 come before priority 0
     if aPriority > 0 and bPriority == 0 then
@@ -113,10 +113,11 @@ function CooldownCursor:RebuildSpellRuleOptions()
   for _, entry in ipairs(sorted) do
     local spellID = entry.spellID
     local rule = entry.rule
+    local settings = rule.settings or {}
     local name = entry.name
-    local enabled = rule.enabled
+    local enabled = settings.enabled
     local icon = entry.icon
-    local priority = rule.priority or 0
+    local priority = settings.priority or 0
     local color, suffix = GetRuleDisplayColor(enabled)
     local priorityText = priority > 0 and ("|cffaaaaaa[%d]|r "):format(priority) or ""
     name = ("%s|cff%s%s %s|r"):format(priorityText, color, name, suffix)
@@ -135,9 +136,9 @@ function CooldownCursor:RebuildSpellRuleOptions()
           name = "Enabled",
           desc = "When enabled, this spell will show cooldowns at your cursor.",
           order = 10,
-          get = function() return rule.enabled ~= false end,
+          get = function() return settings.enabled ~= false end,
           set = function(_, v)
-            rule.enabled = v
+            settings.enabled = v
             self:UpdateDisplay()
             self:RebuildSpellRuleOptions()
             self:NotifyOptionsChanged()
@@ -155,13 +156,13 @@ function CooldownCursor:RebuildSpellRuleOptions()
           disabled = function()
             return CooldownCursor:GetDBValue("stackDirection") == "SINGLE" or
                 CooldownCursorDB.spellRules.settings.disableRules or
-                not rule.enabled
+                not settings.enabled
           end,
           get = function()
-            return rule.priority or 0
+            return settings.priority or 0
           end,
           set = function(_, v)
-            rule.priority = v
+            settings.priority = v
             self:UpdateDisplay()
             -- Debounce the rebuild so slider moves smoothly
             if priorityRebuildTimer then
@@ -195,14 +196,14 @@ function CooldownCursor:RebuildSpellRuleOptions()
           max = 128,
           step = 1,
           disabled = function()
-            return rule.useGlobalIconSize ~= false or not rule.enabled
+            return settings.useGlobalIconSize ~= false or not settings.enabled
           end,
           get = function()
-            return rule.iconSize or CooldownCursor:GetDBValue("iconSize")
+            return settings.iconSize or CooldownCursor:GetDBValue("iconSize")
           end,
           set = function(_, v)
-            rule.iconSize = v
-            rule.useGlobalIconSize = false -- auto-disable inheritance
+            settings.iconSize = v
+            settings.useGlobalIconSize = false -- auto-disable inheritance
             self:UpdateDisplay()
           end,
         },
@@ -213,12 +214,12 @@ function CooldownCursor:RebuildSpellRuleOptions()
           desc = "Use the global icon size instead of a per-spell value.",
           order = 23,
           get = function()
-            return rule.useGlobalIconSize ~= false
+            return settings.useGlobalIconSize ~= false
           end,
           set = function(_, v)
-            rule.useGlobalIconSize = v
+            settings.useGlobalIconSize = v
             if v then
-              rule.iconSize = nil
+              settings.iconSize = nil
             end
             self:UpdateDisplay()
           end,

--- a/Options.lua
+++ b/Options.lua
@@ -1421,7 +1421,9 @@ local options = {
               return { [0] = "|cff888888-- Not available in combat --|r" }
             end
             local values = { [0] = "|cff888888-- Select a spell --|r" }
-            local spells = CooldownCursor:GetCooldownSpells(true, 0, true)
+            local includeNoCooldown = CooldownCursor._includeNoCooldownSpells ~= false
+            local includePets = CooldownCursor._includePetSpells or false
+            local spells = CooldownCursor:GetCooldownSpells(includePets, 0, true, includeNoCooldown)
 
             for _, spell in ipairs(spells) do
               if spell.spellID and spell.name then
@@ -1439,7 +1441,9 @@ local options = {
           end,
           sorting = function()
             -- Return spellIDs sorted alphabetically by spell name
-            local spells = CooldownCursor:GetCooldownSpells(true, 0, true)
+            local includeNoCooldown = CooldownCursor._includeNoCooldownSpells ~= false
+            local includePets = CooldownCursor._includePetSpells or false
+            local spells = CooldownCursor:GetCooldownSpells(includePets, 0, true, includeNoCooldown)
             table.sort(spells, function(a, b)
               return (a.name or ""):lower() < (b.name or ""):lower()
             end)
@@ -1466,12 +1470,51 @@ local options = {
           end,
         },
 
+        includePetSpells = {
+          type = "toggle",
+          name = "Pet Spells",
+          desc = "Include pet spells in the dropdown list.",
+          order = 418.5,
+          width = "normal",
+          disabled = function()
+            return InCombatLockdown()
+          end,
+          get = function()
+            return CooldownCursor._includePetSpells or false
+          end,
+          set = function(_, v)
+            CooldownCursor._includePetSpells = v
+            CooldownCursor._selectedSpellbookSpell = 0
+            CooldownCursor:NotifyOptionsChanged()
+          end,
+        },
+
+        includeNoCooldownSpells = {
+          type = "toggle",
+          name = "Non-Cooldown Spells",
+          desc = "Show spells without cooldowns in the dropdown list.\n\n" ..
+              "Useful for adding spells that don't have a base cooldown (e.g. procs, buffs).",
+          order = 418,
+          width = "normal",
+          disabled = function()
+            return InCombatLockdown()
+          end,
+          get = function()
+            return CooldownCursor._includeNoCooldownSpells ~= false
+          end,
+          set = function(_, v)
+            CooldownCursor._includeNoCooldownSpells = v
+            CooldownCursor._selectedSpellbookSpell = 0
+            CooldownCursor:NotifyOptionsChanged()
+          end,
+        },
+
         addFromSpellbook = {
           type = "execute",
           name = "Add",
           desc = "Add the selected spell to your rules.\n\n" ..
               "|cffaaaaaaTip: Select a spell from the dropdown first.|r",
-          order = 418,
+          order = 417.5,
           width = "half",
           func = function()
             local spellID = CooldownCursor._selectedSpellbookSpell

--- a/Options.lua
+++ b/Options.lua
@@ -446,6 +446,19 @@ local options = {
           end,
         },
 
+        showCharges = {
+          type = "toggle",
+          name = "Show Charges",
+          desc = "Display the current charge count on spell icons for spells with multiple charges.",
+          order = 4.2,
+          width = "normal",
+          get = function() return CooldownCursor:GetDBValue("showCharges") end,
+          set = function(_, v)
+            CooldownCursor:SetDBBoolean("showCharges", v)
+            CooldownCursor:UpdateDisplay()
+          end,
+        },
+
         enabledWarning = {
           type = "description",
           name = function()
@@ -1337,6 +1350,7 @@ local options = {
           max = 32,
           step = 1,
           width = "normal",
+          disabled = function() return CooldownCursor:GetDBValue("showCharges") == false end,
           get = function() return CooldownCursor:GetDBValue("chargeTextSize") end,
           set = function(_, v) CooldownCursor:SetDBNumber("chargeTextSize", v) end,
         },
@@ -1347,6 +1361,7 @@ local options = {
           desc = "Font used for the charge count text.",
           order = 130,
           width = "normal",
+          disabled = function() return CooldownCursor:GetDBValue("showCharges") == false end,
           values = FontValues,
           get = function() return CooldownCursor:GetDBValue("chargeTextFont") end,
           set = function(_, v) CooldownCursor:SetFontPath("chargeTextFont", v) end,
@@ -1358,6 +1373,7 @@ local options = {
           desc = "Font outline type for the charge count text.",
           order = 140,
           width = "normal",
+          disabled = function() return CooldownCursor:GetDBValue("showCharges") == false end,
           values = fontTypeValues,
           get = function() return CooldownCursor:GetDBValue("chargeTextFontType") end,
           set = function(_, v)
@@ -1371,6 +1387,7 @@ local options = {
           hasAlpha = false,
           order = 150,
           width = "normal",
+          disabled = function() return CooldownCursor:GetDBValue("showCharges") == false end,
           get = function() return HexColorGet("chargeTextColor", "FFFFFF") end,
           set = function(_, r, g, b, a) HexColorSet("chargeTextColor", r, g, b, a) end,
         },
@@ -1381,6 +1398,7 @@ local options = {
           desc = "Where to position the charge count on the icon.",
           order = 160,
           width = "normal",
+          disabled = function() return CooldownCursor:GetDBValue("showCharges") == false end,
           values = AnchorValues,
           get = function() return CooldownCursor:GetDBValue("chargeTextAnchor") end,
           set = function(_, v) CooldownCursor:SetDBString("chargeTextAnchor", v) end,

--- a/Options.lua
+++ b/Options.lua
@@ -289,9 +289,9 @@ end
 
 local function ShowBehaviorValues()
   return {
-    [0] = "Auto-Hide After",
-    [1] = "On Cooldown",
-    [2] = "Off Cooldown (Ready)",
+    [0] = "On Cooldown",
+    [1] = "Off Cooldown (Ready)",
+    [2] = "Auto-Hide After",
   }
 end
 
@@ -432,7 +432,8 @@ local options = {
           type = "toggle",
           name = "Show Procs",
           desc = "Enable proc detection for spells that can glow.\n\n" ..
-              "If disabled, proc visuals are hidden and proc-only icons are hidden.",
+              "If disabled, proc visuals are hidden and proc-only icons are hidden.\n\n" .. 
+              "|cffff0000NOTE: Spells must be added to the Spell Rules|r",
           order = 4.1,
           width = "normal",
           get = function() return CooldownCursor:GetDBValue("showProcs") end,
@@ -519,10 +520,10 @@ local options = {
 
         showBehavior = {
           type = "select",
-          name = "Show Behavior |cff345BFF(Experimental)|r",
-          desc = "On Cooldown |cffFF1E34(Experimental)|r - Icons appear when a spell goes on cooldown.\n\n" ..
-              "Off Cooldown |cffFF1E34(Experimental)|r - Icons appear when a spell comes off cooldown and is ready to use again.\n\n" ..
-              "Auto-Hide After |cffFFFFFF(Default/Legacy)|r - Icons appear when a spell goes on cooldown and automatically disappear after a set time. See 'Auto-Hide After' option.",
+          name = "Show Behavior",
+          desc = "On Cooldown - Icons appear when a spell goes on cooldown.\n\n" ..
+              "Off Cooldown - Icons appear when a spell comes off cooldown and is ready to use again.\n\n" ..
+              "Auto-Hide After - Icons appear when a spell goes on cooldown and automatically disappear after a set time. See 'Auto-Hide After' option.",
           order = 25,
           width = "normal",
           values = ShowBehaviorValues(),
@@ -543,7 +544,7 @@ local options = {
           max = 120,
           step = 1,
           disabled = function()
-            return CooldownCursor:GetDBValue("showBehavior") ~= 0
+            return CooldownCursor:GetDBValue("showBehavior") ~= 2
           end,
           get = function() return CooldownCursor:GetDBValue("hideAfter") end,
           set = function(_, v) CooldownCursor:SetHideAfter(v) end,
@@ -745,7 +746,7 @@ local options = {
         procOverlayAtlas = {
           type = "select",
           name = "Proc Overlay Atlas",
-          desc = "Select the atlas used for the proc overlay glow.",
+          desc = "Select the atlas used for the proc overlay glow.\n\nEnable 'Show Procs' in Quick Settings to see proc visuals and options.",
           order = 50,
           width = "normal",
           disabled = function() return CooldownCursor:GetDBValue("showProcs") == false end,
@@ -770,7 +771,7 @@ local options = {
         procOutlineAtlas = {
           type = "select",
           name = "Proc Outline Atlas",
-          desc = "Select the atlas used for the proc outline border.",
+          desc = "Select the atlas used for the proc outline border.\n\nEnable 'Show Procs' in Quick Settings to see proc visuals and options.",
           order = 51,
           width = "normal",
           disabled = function() return CooldownCursor:GetDBValue("showProcs") == false end,

--- a/Options.lua
+++ b/Options.lua
@@ -319,16 +319,16 @@ end
 local function ApplyDisplayModeDefaults(newMode)
   if newMode == "HORIZONTAL" then
     -- Default to RIGHT growth with TOPRIGHT anchor
-    CooldownCursorDB.stackGrowth = "RIGHT"
-    CooldownCursorDB.anchor = "TOPRIGHT"
+    CooldownCursorDB.global.stackGrowth = "RIGHT"
+    CooldownCursorDB.global.anchor = "TOPRIGHT"
   elseif newMode == "VERTICAL" then
     -- Default to DOWN growth with BOTTOM anchor
-    CooldownCursorDB.stackGrowth = "DOWN"
-    CooldownCursorDB.anchor = "BOTTOM"
+    CooldownCursorDB.global.stackGrowth = "DOWN"
+    CooldownCursorDB.global.anchor = "BOTTOM"
   elseif newMode == "RADIUS" then
     -- Default to CLOCKWISE growth with CENTER anchor
-    CooldownCursorDB.stackGrowth = "CLOCKWISE"
-    CooldownCursorDB.anchor = "CENTER"
+    CooldownCursorDB.global.stackGrowth = "CLOCKWISE"
+    CooldownCursorDB.global.anchor = "CENTER"
   end
   -- SINGLE mode: no automatic changes
 end

--- a/Options.lua
+++ b/Options.lua
@@ -1320,6 +1320,71 @@ local options = {
           get = function() return CooldownCursor:GetDBValue("cooldownTextAnchor") end,
           set = function(_, v) CooldownCursor:SetDBString("cooldownTextAnchor", v) end,
         },
+
+        -- Charge Count section
+        chargeCountHeader = {
+          type = "header",
+          name = "Charge Count",
+          order = 110,
+        },
+
+        chargeTextSize = {
+          type = "range",
+          name = "Font Size",
+          desc = "Size of the charge count text.",
+          order = 120,
+          min = 6,
+          max = 32,
+          step = 1,
+          width = "normal",
+          get = function() return CooldownCursor:GetDBValue("chargeTextSize") end,
+          set = function(_, v) CooldownCursor:SetDBNumber("chargeTextSize", v) end,
+        },
+
+        chargeTextFont = {
+          type = "select",
+          name = "Font",
+          desc = "Font used for the charge count text.",
+          order = 130,
+          width = "normal",
+          values = FontValues,
+          get = function() return CooldownCursor:GetDBValue("chargeTextFont") end,
+          set = function(_, v) CooldownCursor:SetFontPath("chargeTextFont", v) end,
+        },
+
+        chargeTextFontType = {
+          type = "select",
+          name = "Font Type",
+          desc = "Font outline type for the charge count text.",
+          order = 140,
+          width = "normal",
+          values = fontTypeValues,
+          get = function() return CooldownCursor:GetDBValue("chargeTextFontType") end,
+          set = function(_, v)
+            CooldownCursor:SetDBString("chargeTextFontType", v)
+          end,
+        },
+
+        chargeTextColor = {
+          type = "color",
+          name = "Color",
+          hasAlpha = false,
+          order = 150,
+          width = "normal",
+          get = function() return HexColorGet("chargeTextColor", "FFFFFF") end,
+          set = function(_, r, g, b, a) HexColorSet("chargeTextColor", r, g, b, a) end,
+        },
+
+        chargeTextAnchor = {
+          type = "select",
+          name = "Position",
+          desc = "Where to position the charge count on the icon.",
+          order = 160,
+          width = "normal",
+          values = AnchorValues,
+          get = function() return CooldownCursor:GetDBValue("chargeTextAnchor") end,
+          set = function(_, v) CooldownCursor:SetDBString("chargeTextAnchor", v) end,
+        },
       },
     },
 

--- a/Options.lua
+++ b/Options.lua
@@ -38,6 +38,21 @@ local function GetRuleDisplayColor(enabled)
   return "ff5555", "(disabled)"
 end
 
+-- Helper to get class-specific rules for the current player
+local function GetClassRulesForUI()
+  CooldownCursorDB.spellRules = CooldownCursorDB.spellRules or {}
+  CooldownCursorDB.spellRules.rules = CooldownCursorDB.spellRules.rules or {}
+
+  local class = CooldownCursor:GetPlayerClass()
+  if not class then return {} end
+
+  if not CooldownCursorDB.spellRules.rules[class] then
+    CooldownCursorDB.spellRules.rules[class] = {}
+  end
+
+  return CooldownCursorDB.spellRules.rules[class]
+end
+
 function CooldownCursor:RebuildSpellRuleOptions()
   local group = self.options.args.spellRulesGroup
   local args = group.args
@@ -49,13 +64,14 @@ function CooldownCursor:RebuildSpellRuleOptions()
     end
   end
 
-  CooldownCursorDB.spellRules = CooldownCursorDB.spellRules or { rules = {} }
+  -- Get class-specific rules
+  local classRules = GetClassRulesForUI()
 
   -- Build sortable list
   local sorted = {}
 
-  for spellID, rule in pairs(CooldownCursorDB.spellRules.rules) do
-    if type(spellID) == "number" then
+  for spellID, rule in pairs(classRules) do
+    if type(spellID) == "number" and C_SpellBook.IsSpellKnown(spellID) then
       local info = C_Spell.GetSpellInfo(spellID)
       local name = info and info.name or ("SpellID " .. spellID)
       local icon = info and info.originalIconID or nil
@@ -1224,10 +1240,61 @@ local options = {
       order = 400,
       args = {
 
+        classHeader = {
+          type = "description",
+          name = function()
+            local class = CooldownCursor:GetPlayerClass()
+            if class then
+              -- Class colors (approximate WoW class colors)
+              local classColors = {
+                WARRIOR = "C69B6D",
+                PALADIN = "F48CBA",
+                HUNTER = "AAD372",
+                ROGUE = "FFF468",
+                PRIEST = "FFFFFF",
+                DEATHKNIGHT = "C41E3A",
+                SHAMAN = "0070DD",
+                MAGE = "3FC7EB",
+                WARLOCK = "8788EE",
+                MONK = "00FF98",
+                DRUID = "FF7C0A",
+                DEMONHUNTER = "A330C9",
+                EVOKER = "33937F",
+              }
+              local color = classColors[class] or "FFFFFF"
+              return string.format("|cff%s%s|r Spell Rules", color, class:gsub("^%l", string.upper):gsub("(%u)", " %1"):sub(2))
+            end
+            return "Spell Rules"
+          end,
+          fontSize = "large",
+          order = 399,
+        },
+
+        specHeader = {
+          type = "description",
+          name = function()
+            local specIndex = GetSpecialization()
+            if specIndex then
+              local _, specName, _, specIcon = GetSpecializationInfo(specIndex)
+              if specName then
+                local iconText = specIcon and string.format("|T%d:16:16:0:0|t ", specIcon) or ""
+                return string.format("%s|cffffff00%s|r Specialization", iconText, specName)
+              end
+            end
+            return ""
+          end,
+          fontSize = "medium",
+          order = 399.5,
+        },
+
         rulesDescription = {
           type = "description",
-          name = "Manage which spells show cooldowns at your cursor.\n\n" ..
-              "|cffaaaaaaTip: Only spells added to rules will show cooldowns. Add spells below to enable tracking.|r",
+          name = function()
+            local class = CooldownCursor:GetPlayerClass()
+            local classText = class and string.format(" for your |cffffd100%s|r", class:lower():gsub("^%l", string.upper)) or ""
+            return "Manage which spells show cooldowns at your cursor" .. classText .. ".\n\n" ..
+                "|cffaaaaaaTip: Spells not known to your current spec are automatically hidden.|r"
+          end,
           order = 400,
         },
 
@@ -1265,7 +1332,7 @@ local options = {
               return { [0] = "|cff888888-- Not available in combat --|r" }
             end
             local values = { [0] = "|cff888888-- Select a spell --|r" }
-            local spells = CooldownCursor:GetCooldownSpells(true, 0)
+            local spells = CooldownCursor:GetCooldownSpells(true, 0, true)
 
             for _, spell in ipairs(spells) do
               if spell.spellID and spell.name then
@@ -1283,7 +1350,7 @@ local options = {
           end,
           sorting = function()
             -- Return spellIDs sorted alphabetically by spell name
-            local spells = CooldownCursor:GetCooldownSpells(true)
+            local spells = CooldownCursor:GetCooldownSpells(true, 0, true)
             table.sort(spells, function(a, b)
               return (a.name or ""):lower() < (b.name or ""):lower()
             end)
@@ -1645,15 +1712,27 @@ local options = {
 
         clearAllSpellRules = {
           type = "execute",
-          name = "Clear All Spell Rules",
-          desc = "Remove all spell rules you have added.\n\n" ..
-              "|cffff8800Warning:|r This cannot be undone!",
+          name = function()
+            local class = CooldownCursor:GetPlayerClass()
+            if class then
+              return "Clear " .. class:gsub("^%l", string.upper):gsub("(%u)", " %1"):sub(2) .. " Spell Rules"
+            end
+            return "Clear All Spell Rules"
+          end,
+          desc = function()
+            local class = CooldownCursor:GetPlayerClass()
+            local classText = class and string.format(" for your %s", class:lower():gsub("^%l", string.upper)) or ""
+            return "Remove all spell rules" .. classText .. ".\n\n" ..
+                "|cffff8800Warning:|r This cannot be undone!"
+          end,
           order = 70,
           confirm = true,
-          confirmText = "Are you sure you want to delete ALL spell rules? This cannot be undone.",
+          confirmText = "Are you sure you want to delete ALL spell rules for this class? This cannot be undone.",
           func = function()
-            CooldownCursorDB.spellRules = CooldownCursorDB.spellRules or {}
-            CooldownCursorDB.spellRules.rules = {}
+            local class = CooldownCursor:GetPlayerClass()
+            if class and CooldownCursorDB.spellRules and CooldownCursorDB.spellRules.rules then
+              CooldownCursorDB.spellRules.rules[class] = {}
+            end
             CooldownCursor:RebuildSpellRuleOptions()
             CooldownCursor:NotifyOptionsChanged()
             CooldownCursor:UpdateDisplay()
@@ -1746,6 +1825,7 @@ CooldownCursor.options = options
 function CooldownCursor:OnOptionsOpened()
   -- Options Panel Opened
   CooldownCursor:HideIconNow()
+  self:RebuildSpellRuleOptions() -- Refresh to show only known spells for current spec
   CooldownCursor:ApplyBreakingChangesAndSetReleaseNotes()
 end
 

--- a/Options.lua
+++ b/Options.lua
@@ -279,6 +279,26 @@ local function ShowBehaviorValues()
   }
 end
 
+local function ProcOverlayAtlasValues()
+  local values = {}
+  local settings = CooldownCursor:GetProcOverlayAtlasSettings() or {}
+  values["none"] = "None"
+  for atlas, data in pairs(settings) do
+    values[atlas] = (data and data.name) or atlas
+  end
+  return values
+end
+
+local function ProcOutlineAtlasValues()
+  local values = {}
+  local settings = CooldownCursor:GetProcOutlineAtlasSettings() or {}
+  values["none"] = "None"
+  for atlas, data in pairs(settings) do
+    values[atlas] = (data and data.name) or atlas
+  end
+  return values
+end
+
 -- Helper to set smart defaults when Display Mode changes
 local function ApplyDisplayModeDefaults(newMode)
   if newMode == "HORIZONTAL" then
@@ -389,6 +409,23 @@ local options = {
             if not v then
               CooldownCursor:HideIconNow()
             end
+          end,
+        },
+
+        showProcs = {
+          type = "toggle",
+          name = "Show Procs",
+          desc = "Enable proc detection for spells that can glow.\n\n" ..
+              "If disabled, proc visuals are hidden and proc-only icons are hidden.",
+          order = 4.1,
+          width = "normal",
+          get = function() return CooldownCursor:GetDBValue("showProcs") end,
+          set = function(_, v)
+            CooldownCursor:SetDBBoolean("showProcs", v)
+            if not v then
+              CooldownCursor:ClearProcStates(true)
+            end
+            CooldownCursor:UpdateDisplay()
           end,
         },
 
@@ -683,11 +720,62 @@ local options = {
           type = "toggle",
           name = "Pop Animation",
           desc = "Icons briefly scale up when they appear.",
-          order = 50,
+          order = 54,
           width = "normal",
           get = function() return CooldownCursor:GetDBValue("animation") end,
           set = function(_, v) CooldownCursor:SetDBBoolean("animation", v) end,
         },
+
+        procOverlayAtlas = {
+          type = "select",
+          name = "Proc Overlay Atlas",
+          desc = "Select the atlas used for the proc overlay glow.",
+          order = 50,
+          width = "normal",
+          disabled = function() return CooldownCursor:GetDBValue("showProcs") == false end,
+          values = ProcOverlayAtlasValues(),
+          get = function() return CooldownCursor:GetDBValue("procOverlayAtlas") end,
+          set = function(_, v)
+            CooldownCursor:SetDBString("procOverlayAtlas", v)
+            CooldownCursor:UpdateDisplay()
+          end,
+        },
+
+        procOverlayColor = {
+          type = "color",
+          name = "Proc Overlay Color",
+          desc = "Tint color for the proc overlay glow.",
+          order = 50.5,
+          disabled = function() return CooldownCursor:GetDBValue("showProcs") == false end,
+          get = function() return HexColorGet("procOverlayColor", "FFFFFF") end,
+          set = function(_, r, g, b, a) HexColorSet("procOverlayColor", r, g, b, a) end,
+        },
+
+        procOutlineAtlas = {
+          type = "select",
+          name = "Proc Outline Atlas",
+          desc = "Select the atlas used for the proc outline border.",
+          order = 51,
+          width = "normal",
+          disabled = function() return CooldownCursor:GetDBValue("showProcs") == false end,
+          values = ProcOutlineAtlasValues(),
+          get = function() return CooldownCursor:GetDBValue("procOutlineAtlas") end,
+          set = function(_, v)
+            CooldownCursor:SetDBString("procOutlineAtlas", v)
+            CooldownCursor:UpdateDisplay()
+          end,
+        },
+
+        procOutlineColor = {
+          type = "color",
+          name = "Proc Outline Color",
+          desc = "Tint color for the proc outline border.",
+          order = 51.5,
+          disabled = function() return CooldownCursor:GetDBValue("showProcs") == false end,
+          get = function() return HexColorGet("procOutlineColor", "FFFFFF") end,
+          set = function(_, r, g, b, a) HexColorSet("procOutlineColor", r, g, b, a) end,
+        },
+
 
         fadeOutDuration = {
           type = "range",
@@ -1265,7 +1353,7 @@ local options = {
               return { [0] = "|cff888888-- Not available in combat --|r" }
             end
             local values = { [0] = "|cff888888-- Select a spell --|r" }
-            local spells = CooldownCursor:GetCooldownSpells(true, 1.5, true)
+            local spells = CooldownCursor:GetCooldownSpells(true, 0, true)
 
             for _, spell in ipairs(spells) do
               if spell.spellID and spell.name then
@@ -1283,7 +1371,7 @@ local options = {
           end,
           sorting = function()
             -- Return spellIDs sorted alphabetically by spell name
-            local spells = CooldownCursor:GetCooldownSpells(true, 1.5, true)
+            local spells = CooldownCursor:GetCooldownSpells(true, 0, true)
             table.sort(spells, function(a, b)
               return (a.name or ""):lower() < (b.name or ""):lower()
             end)

--- a/Spells.lua
+++ b/Spells.lua
@@ -206,8 +206,9 @@ end
 -- @param includePetSpells boolean - Include pet spells
 -- @param minCooldown number - Minimum base cooldown in seconds (default 1.5 to filter GCD-only spells)
 -- @param onlyKnown boolean - Only include spells the player currently knows
+-- @param includeNoCooldown boolean - Also include spells without cooldowns
 -- @return table - Array of cooldown spell data
-function Spells:GetCooldownSpells(includePetSpells, minCooldown, onlyKnown)
+function Spells:GetCooldownSpells(includePetSpells, minCooldown, onlyKnown, includeNoCooldown)
   local allSpells = self:GetAllSpellBookSpells(includePetSpells, false, false)
   local cooldownSpells = {}
 
@@ -215,10 +216,9 @@ function Spells:GetCooldownSpells(includePetSpells, minCooldown, onlyKnown)
   minCooldown = minCooldown or 1.5
 
   for _, spell in ipairs(allSpells) do
-    if spell.hasCooldown
-        and not spell.isPassive
-        and spell.baseCooldown >= minCooldown
+    if not spell.isPassive
         and (not onlyKnown or C_SpellBook.IsSpellKnown(spell.spellID))
+        and (includeNoCooldown or (spell.hasCooldown and spell.baseCooldown >= minCooldown))
     then
       table.insert(cooldownSpells, spell)
     end

--- a/Spells.lua
+++ b/Spells.lua
@@ -204,8 +204,9 @@ end
 --- Get only spells with cooldowns (useful for cooldown tracking)
 -- @param includePetSpells boolean - Include pet spells
 -- @param minCooldown number - Minimum base cooldown in seconds (default 1.5 to filter GCD-only spells)
+-- @param onlyKnown boolean - Only include spells the player currently knows
 -- @return table - Array of cooldown spell data
-function Spells:GetCooldownSpells(includePetSpells, minCooldown)
+function Spells:GetCooldownSpells(includePetSpells, minCooldown, onlyKnown)
   local allSpells = self:GetAllSpellBookSpells(includePetSpells, false, false)
   local cooldownSpells = {}
 
@@ -213,11 +214,12 @@ function Spells:GetCooldownSpells(includePetSpells, minCooldown)
   minCooldown = minCooldown or 1.5
 
   for _, spell in ipairs(allSpells) do
-    if spell.hasCooldown and not spell.isPassive then
-      -- Filter by minimum cooldown if specified
-      if spell.baseCooldown >= minCooldown then
-        table.insert(cooldownSpells, spell)
-      end
+    if spell.hasCooldown
+        and not spell.isPassive
+        and spell.baseCooldown >= minCooldown
+        and (not onlyKnown or C_SpellBook.IsSpellKnown(spell.spellID))
+    then
+      table.insert(cooldownSpells, spell)
     end
   end
 


### PR DESCRIPTION
# Changelog - Version 2.2.0

## Breaking Changes
- Settings have been moved to a 'global' subtable in SavedVariables - existing settings are automatically migrated
- Spell rules are now saved per class - you may need to `/reload` UI for alt characters

## New Features
- **Proc Spell Support:** Show spell icons when procs are active
- **Charge Spell Support:** Show spell icons with charges when active
- Proc visual indicators with customizable overlay and border
- **Class-based Spell Rules:** Each class now has its own separate spell rules
- Spells not known to your current spec are automatically hidden
