### PR TITLE
fix: icon pool corruption causing wrong per-spell sizes after preview…

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -331,19 +331,36 @@ local function InitializeIconPool()
 end
 
 local function GetIconFromPool()
+  local iconFrame
   if #State.iconPool > 0 then
-    return table.remove(State.iconPool, 1)
+    iconFrame = table.remove(State.iconPool, 1)
+  else
+    iconFrame = CreateIconFrame(State.nextIconID)
+    State.nextIconID = State.nextIconID + 1
   end
-  local newIcon = CreateIconFrame(State.nextIconID)
-  State.nextIconID = State.nextIconID + 1
-  return newIcon
+  iconFrame._inPool = false
+  return iconFrame
 end
 
 ReturnIconToPool = function(iconFrame)
   if not iconFrame then return end
 
+  -- Guard against double-return (same frame already in pool)
+  if iconFrame._inPool then return end
+  iconFrame._inPool = true
+
+  -- Stop any playing animations to prevent OnFinished from firing later
+  if iconFrame.showAnim then
+    iconFrame.showAnim:Stop()
+  end
+  if iconFrame.fadeOut then
+    iconFrame.fadeOut:Stop()
+  end
+
+  -- Reset the frame to a clean default state before it goes back into the pool
   iconFrame:Hide()
   iconFrame:SetScript("OnUpdate", nil)
+  iconFrame:SetScale(1)
   iconFrame.spellID = nil
   iconFrame.addedTime = nil
   iconFrame.priority = 0

--- a/Modules/Icons.lua
+++ b/Modules/Icons.lua
@@ -419,6 +419,7 @@ local function SetupNewIcon(spellID, spellInfo, durationObject, fromProc)
 
   -- If this spell is an instant cast or has no cooldown, and it's not from a proc, don't create icon.
   if not fromProc and rule and not metadata.hasCooldown and not metadata.hasCharges then
+    ReturnIconToPool(iconFrame)
     return
   end
 

--- a/Modules/Settings.lua
+++ b/Modules/Settings.lua
@@ -263,8 +263,24 @@ end
 ----------------------------------------------------
 
 function Settings:HideAllIcons(immediate)
-  for spellID, _ in pairs(State.activeIcons) do
-    Internal.RemoveIconForSpell(spellID, immediate or false)
+  -- Directly clean up each icon frame instead of using RemoveIconForSpell,
+  -- which calls SortIcons/UpdateIconPositions after every single removal.
+  for _, iconData in ipairs(State.iconsByPriority) do
+    local iconFrame = iconData.iconFrame
+    if iconFrame then
+      if immediate or CooldownCursorDB.global.fadeOutDuration == 0 then
+        Internal.ReturnIconToPool(iconFrame)
+      else
+        if iconFrame.fadeOut then
+          iconFrame.fadeOut:Stop()
+          local fadeOutAnim = iconFrame.fadeOut:GetAnimations()
+          fadeOutAnim:SetDuration(CooldownCursorDB.global.fadeOutDuration or 0.3)
+          iconFrame.fadeOut:Play()
+        else
+          Internal.ReturnIconToPool(iconFrame)
+        end
+      end
+    end
   end
   State.activeIcons = {}
   State.iconsByPriority = {}


### PR DESCRIPTION
… toggle

Fix icon frame pool corruption that caused per-spell icon sizes to break after toggling preview mode multiple times, also affecting live cooldown tracking afterward.

- HideAllIcons: rewrite to directly return frames to pool via ipairs on iconsByPriority array, instead of calling RemoveIconForSpell per-icon which ran SortIcons/UpdateIconPositions after every removal, mutating shared state during cleanup
- ReturnIconToPool: add _inPool guard to prevent double-return, stop showAnim/fadeOut animations before returning to prevent stale OnFinished callbacks, reset frame scale
- SetupNewIcon: return icon frame to pool on early-return guard to prevent pool leak when spell has no cooldown/charges and isn't a proc