### PR TITLE
fix: Remove dead anchor code from Cursor.lua and invalidate spellbook…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ luac.out
 .vscode/settings.json
 Libs/
 dont_commit/
+.lh/

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -8,3 +8,4 @@ externals:
 
 ignore:
   - assets
+  - docs

--- a/Config/Defaults.lua
+++ b/Config/Defaults.lua
@@ -275,6 +275,16 @@ function Defaults:ApplyBreakingChangesAndSetReleaseNotes()
   local _cleanedFlatRulesCheckMsg = CooldownCursorDB._migrated.cleanedFlatRules and "Your migration is marked cleaned" or
   "Your migration rules are pending cleanup"
   local releaseNotesByVersion = {
+    ["2.3.1"] = {
+      newFeatures = {
+        "Added debugging utilities and inline documentation to the Debug module",
+      },
+      fixes = {
+        "Fixed stale spell book data after a spec change — spell cache is now force-expired on PLAYER_SPECIALIZATION_CHANGED, preventing outdated spell data for up to 60 seconds after swapping specs",
+        "Removed duplicated anchor logic from Cursor.lua (was silently overwritten by Anchor.lua at load time — dead code)",
+        "Refactored event handling in Init.lua to a dispatch table for cleaner per-event logic and easier future additions",
+      },
+    },
     ["2.3.0"] = {
       newFeatures = {
         "Added Screen position mode with a draggable anchor (visible in Preview/Options)",

--- a/Config/Defaults.lua
+++ b/Config/Defaults.lua
@@ -275,6 +275,16 @@ function Defaults:ApplyBreakingChangesAndSetReleaseNotes()
   local _cleanedFlatRulesCheckMsg = CooldownCursorDB._migrated.cleanedFlatRules and "Your migration is marked cleaned" or
   "Your migration rules are pending cleanup"
   local releaseNotesByVersion = {
+    ["2.3.1"] = {
+      newFeatures = {
+        "Added debugging utilities and inline documentation to the Debug module",
+      },
+      fixes = {
+        "Fixed stale spell book data after a spec change, spell cache is now force-expired on PLAYER_SPECIALIZATION_CHANGED, preventing outdated spell data for up to 60 seconds after swapping specs",
+        "Removed duplicated anchor logic from Cursor.lua (was silently overwritten by Anchor.lua at load time)",
+        "Refactored event handling in Init.lua to a dispatch table for cleaner per-event logic and easier future additions",
+      },
+    },
     ["2.3.0"] = {
       newFeatures = {
         "Added Screen position mode with a draggable anchor (visible in Preview/Options)",

--- a/CooldownCursor.toc
+++ b/CooldownCursor.toc
@@ -2,7 +2,7 @@
 ## Title: CooldownCursor
 ## Notes: Shows cooldown timers at your cursor position
 ## Author: jrosco
-## Version: 2.3.0
+## Version: 2.3.1
 ## SavedVariables: CooldownCursorDB
 ## OptionalDeps: Masque
 
@@ -18,6 +18,7 @@ Modules\Anchor.lua
 Modules\Cooldown.lua
 Modules\Settings.lua
 Modules\Preview.lua
+Modules\Debug.lua
 Init.lua
 Options.lua
 Slash.lua

--- a/Init.lua
+++ b/Init.lua
@@ -81,217 +81,225 @@ local function CheckMountedState()
 end
 
 ----------------------------------------------------
--- Event handler
+-- Guard helper
+-- Returns true if the event should be suppressed
+-- due to combat/show-when state or mounted state.
 ----------------------------------------------------
-local SPELL_EVENTS = {
-  UNIT_SPELLCAST_FAILED = true,
-  UNIT_SPELLCAST_SENT = true,
-  UNIT_SPELLCAST_SUCCEEDED = true,
-  SPELL_UPDATE_COOLDOWN = true,
-  SPELL_UPDATE_USABLE = true,
-}
+local function IsGuarded()
+  return CheckShowWhenState() or CheckMountedState()
+end
+
+----------------------------------------------------
+-- Spell event debounce + processing
+----------------------------------------------------
 local pendingSpellTimers = {}
 
-CooldownCursor:SetScript("OnEvent", function(self, event, ...)
-  local unit
-  if event == "ADDON_LOADED" then
-    local name = ...
-    if name ~= addonName then return end
-    self:ApplyDefaults()
-    RefreshScreenMetrics()
-    self:InitMultiIconSystem()
-    self:UpdateDisplay()
-    if ApplyPositionMode then
-      ApplyPositionMode()
-    end
-    self:InitAce3Options()
-    self:UnregisterEvent("ADDON_LOADED")
-    State.inCombat = InCombatLockdown()
-    return
-  end
+local function ProcessSpellEvent(spellID, hasCharges)
+  if pendingSpellTimers[spellID] then return end
+  pendingSpellTimers[spellID] = true
 
-  if event == "PLAYER_SPECIALIZATION_CHANGED" then
-    unit = ...
-    if unit == "player" then
-      wipe(State.knownSpellCache)
-      CooldownCursor:HideAllIcons(true)
-      ApplyShowBehavior()
+  -- Delay slightly to allow cooldown to register
+  C_Timer.After(0.01, function()
+    pendingSpellTimers[spellID] = nil
+    local durationObj = C_Spell.GetSpellCooldownDuration(spellID)
+    if not durationObj then return end
+
+    local inRange = C_Spell.IsSpellInRange(spellID)
+    if inRange == false and
+      CooldownCursorDB.global.showBehavior ~= SHOW_BEHAVIOR.OFF_COOLDOWN then
       return
     end
-  end
 
-  -- Detect mount/dismount
-  if event == "PLAYER_MOUNT_DISPLAY_CHANGED" then
-    CheckMountedState()
-    return
-  end
-
-  if event == "SPELL_UPDATE_CHARGES" then
-    if CheckShowWhenState() then return end
-    if CheckMountedState() then return end
-    if CooldownCursorDB.global.showCharges ~= false then
-      for spellID, iconData in pairs(State.activeIcons) do
-        if iconData and iconData.iconFrame and iconData.hasCharges then
-          UpdateChargeCount(iconData.iconFrame, spellID)
-        end
-      end
-      ApplyShowBehavior()
+    if hasCharges then
+      local iconFrame = ShowSpellIcon(spellID, durationObj)
+      UpdateChargeCount(iconFrame, spellID)
+    else
+      ShowSpellIcon(spellID, durationObj)
     end
-    return
+
+    ApplyShowBehavior()
+  end)
+end
+
+----------------------------------------------------
+-- Shared handler for spell cast / cooldown events
+-- Covers: UNIT_SPELLCAST_SENT, UNIT_SPELLCAST_SUCCEEDED,
+--         UNIT_SPELLCAST_FAILED, SPELL_UPDATE_COOLDOWN
+----------------------------------------------------
+local SPELL_CAST_EVENTS = {
+  UNIT_SPELLCAST_FAILED    = true,
+  UNIT_SPELLCAST_SENT      = true,
+  UNIT_SPELLCAST_SUCCEEDED = true,
+  SPELL_UPDATE_COOLDOWN    = true,
+}
+
+local function HandleSpellCastEvent(self, event, ...)
+  if CooldownCursorDB.global.enabled == false then return end
+  if IsGuarded() then return end
+
+  local spellID
+  if event == "SPELL_UPDATE_COOLDOWN" then
+    -- provides spellID, baseSpellID, category, startRecoveryCategory
+    spellID = ...
+  elseif event == "UNIT_SPELLCAST_SENT" then
+    local unit, _, _, sid = ...
+    if unit ~= "player" then return end
+    spellID = sid
+  else
+    local unit, _, sid = ...
+    if unit ~= "player" then return end
+    spellID = sid
   end
 
-  if event == "SPELL_ACTIVATION_OVERLAY_GLOW_SHOW" then
-    if CheckShowWhenState() then return end
-    if CheckMountedState() then return end
-    local spellID = ...
-    if not spellID then return end
-    if CooldownCursorDB.global.showProcs == false then return end
-
-    local show = CooldownCursor:GetSpellRule(spellID)
-    if not show then return end
-    State.activeProcSpells[spellID] = true
-    State.procCapableSpells[spellID] = true
-    local durationObj = C_Spell.GetSpellCooldownDuration(spellID)
-    local hadIcon = State.activeIcons[spellID] ~= nil
-    local iconFrame, iconData = ShowSpellIcon(spellID, durationObj, true)
-    if iconFrame and iconData then
-      iconData.procActive = true
-      iconFrame.procActive = true
-      if not hadIcon then
-        iconData.procOnly = true
-        iconFrame.procOnly = true
-      end
-      if iconFrame.procOverlay then
-        if IsProcOverlayEnabled() then
-          iconFrame.procOverlay:Show()
-        else
-          iconFrame.procOverlay:Hide()
-        end
-      end
-      if iconFrame.procOutline and IsProcOutlineEnabled() then
-        iconFrame.procOutline:Show()
-      end
-    end
-    return
-  end
-
-  if event == "SPELL_ACTIVATION_OVERLAY_GLOW_HIDE" then
-    local spellID = ...
-    if not spellID then return end
-    if CooldownCursorDB.global.showProcs == false then return end
-    State.activeProcSpells[spellID] = nil
-    local iconData = State.activeIcons[spellID]
-    if iconData and iconData.iconFrame then
-      local iconFrame = iconData.iconFrame
-      iconData.procActive = false
-      iconFrame.procActive = false
-      if iconFrame.procOverlay then
-        iconFrame.procOverlay:Hide()
-      end
-      if iconFrame.procOutline then
-        iconFrame.procOutline:Hide()
-      end
-      if iconData.procOnly then
-        RemoveIconForSpell(spellID, true)
-      end
-    end
-    return
-  end
-
-  if event == "UI_SCALE_CHANGED" or event == "DISPLAY_SIZE_CHANGED" then
-    RefreshScreenMetrics()
-    return
-  end
-
-  if event == "PLAYER_REGEN_DISABLED" then
-    State.inCombat = true
-    if not CheckShowWhenState(true) then
-      ApplyShowBehavior()
-    end
-    return
-  end
-
-  if event == "PLAYER_REGEN_ENABLED" then
-    State.inCombat = false
-    if not CheckShowWhenState(true) then
-      ApplyShowBehavior()
-    end
-    return
-  end
-
-  if CheckShowWhenState() then return end
-
-  if CheckMountedState() then return end
-
-  if event == "SPELL_UPDATE_USABLE" or event == "PLAYER_ENTERING_WORLD" then
+  if not spellID then
     ApplyShowBehavior()
     return
   end
 
-  if SPELL_EVENTS[event] then
-    -- Check if addon is enabled
-    if CooldownCursorDB.global.enabled == false then
-      return
+  local show, rule = self:GetSpellRule(spellID)
+  if not show then return end
+
+  local hasCharges = rule and rule.metadata and rule.metadata.hasCharges or false
+  ProcessSpellEvent(spellID, hasCharges)
+end
+
+----------------------------------------------------
+-- Event handler dispatch table
+----------------------------------------------------
+local eventHandlers = {}
+
+eventHandlers.ADDON_LOADED = function(self, name)
+  if name ~= addonName then return end
+  self:ApplyDefaults()
+  RefreshScreenMetrics()
+  self:InitMultiIconSystem()
+  self:UpdateDisplay()
+  if ApplyPositionMode then ApplyPositionMode() end
+  self:InitAce3Options()
+  self:UnregisterEvent("ADDON_LOADED")
+  State.inCombat = InCombatLockdown()
+end
+
+eventHandlers.PLAYER_SPECIALIZATION_CHANGED = function(self, unit)
+  if unit ~= "player" then return end
+  wipe(State.knownSpellCache)
+  self:InvalidateSpellBookCache()
+  self:HideAllIcons(true)
+  ApplyShowBehavior()
+end
+
+eventHandlers.PLAYER_MOUNT_DISPLAY_CHANGED = function(_)
+  CheckMountedState()
+end
+
+eventHandlers.PLAYER_REGEN_DISABLED = function(_)
+  State.inCombat = true
+  if not CheckShowWhenState(true) then
+    ApplyShowBehavior()
+  end
+end
+
+eventHandlers.PLAYER_REGEN_ENABLED = function(_)
+  State.inCombat = false
+  if not CheckShowWhenState(true) then
+    ApplyShowBehavior()
+  end
+end
+
+eventHandlers.UI_SCALE_CHANGED = function(_)
+  RefreshScreenMetrics()
+end
+eventHandlers.DISPLAY_SIZE_CHANGED = eventHandlers.UI_SCALE_CHANGED
+
+eventHandlers.SPELL_UPDATE_USABLE = function(_)
+  if IsGuarded() then return end
+  ApplyShowBehavior()
+end
+
+eventHandlers.PLAYER_ENTERING_WORLD = function(_)
+  if IsGuarded() then return end
+  ApplyShowBehavior()
+end
+
+eventHandlers.SPELL_UPDATE_CHARGES = function(_)
+  if IsGuarded() then return end
+  if CooldownCursorDB.global.showCharges == false then return end
+  for spellID, iconData in pairs(State.activeIcons) do
+    if iconData and iconData.iconFrame and iconData.hasCharges then
+      UpdateChargeCount(iconData.iconFrame, spellID)
     end
+  end
+  ApplyShowBehavior()
+end
 
-    local spellID
+eventHandlers.SPELL_ACTIVATION_OVERLAY_GLOW_SHOW = function(self, spellID)
+  if not spellID then return end
+  if CooldownCursorDB.global.showProcs == false then return end
+  if IsGuarded() then return end
 
-    -- SPELL_UPDATE_COOLDOWN (11.1.5+) provides spellID, baseSpellID,
-    -- category, startRecoveryCategory. A nil spellID means all cooldowns
-    -- should be refreshed (handled by the nil check below).
-    if event == "SPELL_UPDATE_COOLDOWN" then
-      spellID, _, _, _ = ...
-    else
-      if event == "UNIT_SPELLCAST_SENT" then
-        unit, _, _, spellID = ...
+  local show = self:GetSpellRule(spellID)
+  if not show then return end
+
+  State.activeProcSpells[spellID] = true
+  State.procCapableSpells[spellID] = true
+  local hadIcon = State.activeIcons[spellID] ~= nil
+  local durationObj = C_Spell.GetSpellCooldownDuration(spellID)
+  local iconFrame, iconData = ShowSpellIcon(spellID, durationObj, true)
+  if iconFrame and iconData then
+    iconData.procActive = true
+    iconFrame.procActive = true
+    if not hadIcon then
+      iconData.procOnly = true
+      iconFrame.procOnly = true
+    end
+    if iconFrame.procOverlay then
+      if IsProcOverlayEnabled() then
+        iconFrame.procOverlay:Show()
       else
-        unit, _, spellID = ...
+        iconFrame.procOverlay:Hide()
       end
-      if unit ~= "player" then return end
     end
-    if not spellID then
-      ApplyShowBehavior()
-      return
+    if iconFrame.procOutline and IsProcOutlineEnabled() then
+      iconFrame.procOutline:Show()
     end
+  end
+end
 
-    -- Check user spell rules before doing any cooldown queries
-    local show, rule = CooldownCursor:GetSpellRule(spellID)
-    if not show then return end
-    local hasCharges = rule and rule.metadata and rule.metadata.hasCharges or false
+eventHandlers.SPELL_ACTIVATION_OVERLAY_GLOW_HIDE = function(_, spellID)
+  if not spellID then return end
+  if CooldownCursorDB.global.showProcs == false then return end
 
-    -- Debounce: skip if a timer is already pending for this spellID
-    if not pendingSpellTimers[spellID] then
-      pendingSpellTimers[spellID] = true
-      -- Delay slightly to allow cooldown to register
-      C_Timer.After(0.01, function()
-        pendingSpellTimers[spellID] = nil
-        local durationObj = C_Spell.GetSpellCooldownDuration(spellID)
+  State.activeProcSpells[spellID] = nil
+  local iconData = State.activeIcons[spellID]
+  if not (iconData and iconData.iconFrame) then return end
 
-        if not durationObj then return end
+  local iconFrame = iconData.iconFrame
+  iconData.procActive = false
+  iconFrame.procActive = false
+  if iconFrame.procOverlay then iconFrame.procOverlay:Hide() end
+  if iconFrame.procOutline then iconFrame.procOutline:Hide() end
+  if iconData.procOnly then
+    RemoveIconForSpell(spellID, true)
+  end
+end
 
-        -- local usable = C_Spell.IsSpellUsable(spellID)
-        local inRange = C_Spell.IsSpellInRange(spellID)
+-- Wire the four spell cast/cooldown events to the shared handler
+for eventName in pairs(SPELL_CAST_EVENTS) do
+  eventHandlers[eventName] = function(self, ...)
+    HandleSpellCastEvent(self, eventName, ...)
+  end
+end
 
-        -- Check spell usability
-        if inRange == false and
-          CooldownCursorDB.global.showBehavior ~= SHOW_BEHAVIOR.OFF_COOLDOWN then
-          return
-        end
-
-        if hasCharges then
-          local iconFrame, _ = ShowSpellIcon(spellID, durationObj)
-          UpdateChargeCount(iconFrame, spellID)
-          ApplyShowBehavior()
-          return
-        end
-
-        if durationObj then
-          ShowSpellIcon(spellID, durationObj)
-        end
-
-        ApplyShowBehavior()
-      end)
-    end
+----------------------------------------------------
+-- Event dispatcher
+----------------------------------------------------
+CooldownCursor:SetScript("OnEvent", function(self, event, ...)
+  if Internal.LogEvent then
+    Internal.LogEvent(event, ...)
+  end
+  local handler = eventHandlers[event]
+  if handler then
+    handler(self, ...)
   end
 end)
 
@@ -314,4 +322,3 @@ CooldownCursor:RegisterEvent("UI_SCALE_CHANGED")
 CooldownCursor:RegisterEvent("DISPLAY_SIZE_CHANGED")
 CooldownCursor:RegisterEvent("PLAYER_MOUNT_DISPLAY_CHANGED")
 CooldownCursor:RegisterEvent("PLAYER_ENTERING_WORLD")
-

--- a/Modules/Cursor.lua
+++ b/Modules/Cursor.lua
@@ -5,12 +5,8 @@
 ----------------------------------------------------
 local _, addonTable = ...
 
-local C = addonTable.Constants
 local defaults = addonTable.Defaults
 local State = addonTable.State
-local Internal = addonTable.Internal
-
-local POSITION_MODE = C.POSITION_MODE
 
 ----------------------------------------------------
 -- Anchor Positioning
@@ -69,127 +65,6 @@ local function RefreshCachedSettings()
   State.cachedIconHide = CooldownCursorDB.global.iconHide or false
   State.cachedAnchorOX, State.cachedAnchorOY = AnchorOffsets(State.cachedAnchor, State.cachedIconSize, State.cachedAnchorPadding)
   State.cachedHalfSize = State.cachedIconSize / 2
-end
-
-----------------------------------------------------
--- Screen Anchor (Drag)
-----------------------------------------------------
-local anchorFrame
-
-local function EnsureAnchorFrame()
-  if anchorFrame then return anchorFrame end
-
-  anchorFrame = CreateFrame("Frame", "CooldownCursorAnchor", UIParent)
-  anchorFrame:SetSize(32, 32)
-  anchorFrame:SetFrameStrata("DIALOG")
-  anchorFrame:SetClampedToScreen(true)
-  anchorFrame:EnableMouse(true)
-  anchorFrame:SetMovable(true)
-  anchorFrame:RegisterForDrag("LeftButton")
-  anchorFrame:Hide()
-
-  local tex = anchorFrame:CreateTexture(nil, "OVERLAY")
-  tex:SetAllPoints()
-  tex:SetColorTexture(0, 1, 0, 0.15)
-  anchorFrame._bg = tex
-
-  local border = anchorFrame:CreateTexture(nil, "BORDER")
-  border:SetPoint("TOPLEFT", -1, 1)
-  border:SetPoint("BOTTOMRIGHT", 1, -1)
-  border:SetColorTexture(0, 1, 0, 0.6)
-  anchorFrame._border = border
-
-  local label = anchorFrame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-  label:SetPoint("TOP", anchorFrame, "BOTTOM", 0, -2)
-  label:SetText("CooldownCursor")
-  anchorFrame._label = label
-
-  anchorFrame:SetScript("OnDragStart", function(self)
-    if InCombatLockdown() then return end
-    local mode = CooldownCursorDB.global.positionMode or defaults.positionMode
-    if mode ~= POSITION_MODE.SCREEN then return end
-    self:StartMoving()
-  end)
-
-  anchorFrame:SetScript("OnDragStop", function(self)
-    self:StopMovingOrSizing()
-    local ux, uy = UIParent:GetCenter()
-    local ax, ay = self:GetCenter()
-    if ux and uy and ax and ay then
-      CooldownCursorDB.global.offsetX = ax - ux
-      CooldownCursorDB.global.offsetY = ay - uy
-    end
-    if Internal and Internal.UpdateIconPositions then
-      Internal.UpdateIconPositions()
-    end
-  end)
-
-  return anchorFrame
-end
-
-local function ApplyAnchorPosition()
-  local anchor = EnsureAnchorFrame()
-  local ox = CooldownCursorDB.global.offsetX or defaults.offsetX or 0
-  local oy = CooldownCursorDB.global.offsetY or defaults.offsetY or 0
-  anchor:ClearAllPoints()
-  anchor:SetPoint("CENTER", UIParent, "CENTER", ox, oy)
-end
-
-local function IsScreenMode()
-  local mode = CooldownCursorDB.global.positionMode or defaults.positionMode
-  return mode == POSITION_MODE.SCREEN
-end
-
-local function UpdateAnchorVisibility()
-  if not IsScreenMode() then
-    if anchorFrame then anchorFrame:Hide() end
-    return
-  end
-
-  ApplyAnchorPosition()
-  if State.previewActive or State.optionsOpen then
-    anchorFrame:Show()
-  else
-    anchorFrame:Hide()
-  end
-end
-
-local function ApplyScreenAnchors()
-  if not IsScreenMode() then return end
-  ApplyAnchorPosition()
-  for _, iconData in ipairs(State.iconsByPriority) do
-    local iconFrame = iconData.iconFrame
-    if iconFrame then
-      iconFrame:ClearAllPoints()
-      iconFrame:SetPoint("CENTER", anchorFrame, "CENTER",
-        iconFrame.stackOffsetX or 0,
-        iconFrame.stackOffsetY or 0
-      )
-    end
-  end
-end
-
-local function ApplyPositionMode()
-  if IsScreenMode() then
-    UpdateAnchorVisibility()
-    for _, iconData in ipairs(State.iconsByPriority) do
-      local iconFrame = iconData.iconFrame
-      if iconFrame then
-        iconFrame:SetScript("OnUpdate", nil)
-      end
-    end
-    if Internal and Internal.UpdateIconPositions then
-      Internal.UpdateIconPositions()
-    end
-  else
-    if anchorFrame then anchorFrame:Hide() end
-    for _, iconData in ipairs(State.iconsByPriority) do
-      local iconFrame = iconData.iconFrame
-      if iconFrame then
-        iconFrame:SetScript("OnUpdate", addonTable.Internal.UpdateCooldownIconFrame)
-      end
-    end
-  end
 end
 
 ----------------------------------------------------
@@ -298,8 +173,5 @@ end
 ----------------------------------------------------
 addonTable.Internal.UpdateCooldownIconFrame = UpdateCooldownIconFrame
 addonTable.Internal.RefreshCachedSettings = RefreshCachedSettings
-addonTable.Internal.UpdateAnchorVisibility = UpdateAnchorVisibility
-addonTable.Internal.ApplyScreenAnchors = ApplyScreenAnchors
-addonTable.Internal.ApplyPositionMode = ApplyPositionMode
 
 addonTable.Modules.Cursor = {}

--- a/Modules/Debug.lua
+++ b/Modules/Debug.lua
@@ -1,0 +1,358 @@
+----------------------------------------------------
+-- CooldownCursor: Debug Module
+-- Development helpers, state inspection, event logging
+----------------------------------------------------
+local _, addonTable = ...
+
+local State = addonTable.State
+local Internal = addonTable.Internal
+
+local PREFIX = "|cffff9900[CC Debug]|r"
+local MAX_EVENT_LOG = 50
+
+----------------------------------------------------
+-- Helpers
+----------------------------------------------------
+local debugMode      = false  -- resets to false on every reload
+local debugLogEvents = true   -- event printing defaults on when debug is enabled
+
+local function IsDebugEnabled()
+  return debugMode
+end
+
+local function IsEventLoggingEnabled()
+  return debugMode and debugLogEvents
+end
+
+local function DebugLog(...)
+  if not IsDebugEnabled() then return end
+  print(PREFIX, ...)
+end
+
+local function CountTable(t)
+  local n = 0
+  for _ in pairs(t) do n = n + 1 end
+  return n
+end
+
+----------------------------------------------------
+-- Event log (ring buffer) + filter
+----------------------------------------------------
+local eventLog    = {}
+local eventFilter = {}  -- set of uppercase event names; empty = all events pass
+
+local function PassesFilter(event)
+  return next(eventFilter) == nil or eventFilter[event] == true
+end
+
+local function LogEvent(event, ...)
+  if not IsDebugEnabled() then return end
+  if not PassesFilter(event) then return end
+  if #eventLog >= MAX_EVENT_LOG then
+    table.remove(eventLog, 1)
+  end
+  table.insert(eventLog, { time = GetTime(), event = event, args = { ... } })
+  -- Only print to chat if event logging is enabled (separate toggle)
+  if IsEventLoggingEnabled() then
+    DebugLog("EVENT:", event, ...)
+  end
+end
+
+----------------------------------------------------
+-- Debug Module
+----------------------------------------------------
+local Debug = {}
+
+function Debug:Toggle()
+  debugMode = not debugMode
+  print(PREFIX, debugMode and "|cff00ff00ON|r" or "|cffff0000OFF|r")
+  if debugMode then
+    local evtStatus = debugLogEvents and "|cff00ff00on|r" or "|cffff0000off|r"
+    print(PREFIX, "Event logging:", evtStatus, "— toggle with /cdc debug events")
+    print(PREFIX, "Subcommands: state | icons | rules | spell <id> | pool | events | log | cache | filter")
+  end
+end
+
+----------------------------------------------------
+-- /cdc debug events  (toggle event printing)
+----------------------------------------------------
+function Debug:ToggleEvents()
+  debugLogEvents = not debugLogEvents
+  local status = debugLogEvents and "|cff00ff00ON|r" or "|cffff0000OFF|r"
+  print(PREFIX, "Event logging:", status)
+  if not debugLogEvents then
+    print(PREFIX, "(events still recorded — use /cdc debug log to view)")
+  end
+end
+
+----------------------------------------------------
+-- /cdc debug filter [EVENT_NAME|clear]
+----------------------------------------------------
+function Debug:ToggleFilter(arg)
+  if not arg or arg == "" then
+    local count = CountTable(eventFilter)
+    if count == 0 then
+      print(PREFIX, "No event filter active (all events recorded)")
+    else
+      print(PREFIX, "Active filter (" .. count .. "):")
+      for name in pairs(eventFilter) do
+        print(PREFIX, " -", name)
+      end
+    end
+    return
+  end
+  if arg == "clear" then
+    eventFilter = {}
+    print(PREFIX, "Event filter cleared (all events recorded)")
+    return
+  end
+  local name = arg:upper()
+  if eventFilter[name] then
+    eventFilter[name] = nil
+    print(PREFIX, "Filter removed:", name)
+  else
+    eventFilter[name] = true
+    print(PREFIX, "Filter added:", name)
+  end
+  local count = CountTable(eventFilter)
+  if count > 0 then
+    print(PREFIX, count, "filter(s) active — only matching events recorded")
+  else
+    print(PREFIX, "No filters active — all events recorded")
+  end
+end
+
+----------------------------------------------------
+-- /cdc debug state
+----------------------------------------------------
+function Debug:DumpState()
+  print(PREFIX, "=== State ===")
+  print(PREFIX, "inCombat         :", tostring(State.inCombat))
+  print(PREFIX, "previewActive    :", tostring(State.previewActive))
+  print(PREFIX, "optionsOpen      :", tostring(State.optionsOpen))
+  print(PREFIX, "playerClass      :", tostring(State.playerClass))
+  print(PREFIX, "activeIcons      :", #State.iconsByPriority)
+  print(PREFIX, "iconPool         :", #State.iconPool, "available,", State.nextIconID - 1, "allocated")
+  print(PREFIX, "activeProcSpells :", CountTable(State.activeProcSpells))
+  print(PREFIX, "procCapableSpells:", CountTable(State.procCapableSpells))
+  print(PREFIX, "knownSpellCache  :", CountTable(State.knownSpellCache), "entries")
+  print(PREFIX, "cachedUIScale    :", State.cachedUIScale)
+  print(PREFIX, "cachedScreen     :", State.cachedScreenW, "x", State.cachedScreenH)
+  print(PREFIX, "cachedIconSize   :", State.cachedIconSize)
+  print(PREFIX, "cachedAnchor     :", State.cachedAnchor)
+  print(PREFIX, "positionMode     :", CooldownCursorDB.global.positionMode)
+  print(PREFIX, "showBehavior     :", CooldownCursorDB.global.showBehavior)
+  print(PREFIX, "showWhen         :", CooldownCursorDB.global.showWhen)
+end
+
+----------------------------------------------------
+-- /cdc debug icons
+----------------------------------------------------
+function Debug:DumpIcons()
+  local count = #State.iconsByPriority
+  print(PREFIX, "=== Active Icons (" .. count .. ") ===")
+  if count == 0 then
+    print(PREFIX, "(none)")
+    return
+  end
+  for i, iconData in ipairs(State.iconsByPriority) do
+    local spellID = iconData.spellID
+    local info = C_Spell.GetSpellInfo(spellID)
+    local name = info and info.name or "Unknown"
+    local iconFrame = iconData.iconFrame
+    local shown = iconFrame and iconFrame:IsShown() and "shown" or "hidden"
+    local alpha = iconFrame and string.format("%.2f", iconFrame:GetAlpha()) or "?"
+    local onCD = (iconFrame and iconFrame.cooldown and iconFrame.cooldown:IsShown())
+      and "|cffff4400on-cd|r" or "|cff00ff00off-cd|r"
+    print(PREFIX, string.format(
+      "[%d] %d %-22s prio:%-2d proc:%-5s procOnly:%-5s charges:%-5s %s alpha:%s %s",
+      i, spellID, name,
+      iconData.priority or 0,
+      tostring(iconData.procActive),
+      tostring(iconData.procOnly),
+      tostring(iconData.hasCharges),
+      shown, alpha, onCD
+    ))
+  end
+end
+
+----------------------------------------------------
+-- /cdc debug rules
+----------------------------------------------------
+function Debug:DumpRules()
+  local classRules = Internal.GetClassRules and Internal.GetClassRules()
+  if not classRules then
+    print(PREFIX, "No class rules found")
+    return
+  end
+  local sorted = {}
+  for spellID in pairs(classRules) do
+    table.insert(sorted, spellID)
+  end
+  table.sort(sorted)
+  print(PREFIX, "=== Spell Rules (" .. #sorted .. ") ===")
+  for _, spellID in ipairs(sorted) do
+    local rule = classRules[spellID]
+    local info = C_Spell.GetSpellInfo(spellID)
+    local name = info and info.name or "Unknown"
+    local settings = rule.settings or {}
+    local metadata = rule.metadata or {}
+    local enabledStr = settings.enabled ~= false
+      and "|cff00ff00on|r" or "|cffff0000off|r"
+    local activeStr = State.activeIcons[spellID] ~= nil
+      and "|cff00ff00active|r" or "inactive"
+    print(PREFIX, string.format(
+      "  [%d] %-24s %s | prio:%-2s | cd:%.1fs | charges:%-5s | %s",
+      spellID, name, enabledStr,
+      tostring(settings.priority or 0),
+      metadata.baseCooldown or 0,
+      tostring(metadata.hasCharges or false),
+      activeStr
+    ))
+  end
+end
+
+----------------------------------------------------
+-- /cdc debug spell <id>
+----------------------------------------------------
+function Debug:DumpSpell(arg)
+  local spellID = tonumber(arg)
+  if not spellID then
+    print(PREFIX, "Usage: /cdc debug spell <spellID>")
+    return
+  end
+  local info = C_Spell.GetSpellInfo(spellID)
+  if not info then
+    print(PREFIX, "No info found for spellID:", spellID)
+    return
+  end
+  print(PREFIX, "=== Spell", spellID, "(" .. (info.name or "?") .. ") ===")
+  print(PREFIX, "Icon ID  :", info.iconID)
+  print(PREFIX, "CastTime :", info.castTime / 1000, "sec")
+  print(PREFIX, "Range    :", info.minRange, "-", info.maxRange)
+
+  local cd = C_Spell.GetSpellCooldown(spellID)
+  if cd then
+    print(PREFIX, "Cooldown : start:", cd.startTime, "| duration:", cd.duration, "| enabled:", tostring(cd.isEnabled))
+  end
+
+  local cdDur = C_Spell.GetSpellCooldownDuration(spellID)
+  print(PREFIX, "CD Dur   :", cdDur and tostring(cdDur) or "nil (not on cooldown)")
+
+  local charges = C_Spell.GetSpellCharges(spellID)
+  if charges then
+    print(PREFIX, "Charges  :", charges.currentCharges, "/", charges.maxCharges,
+      "| recovery:", charges.cooldownDuration, "s")
+  else
+    print(PREFIX, "Charges  : none")
+  end
+
+  local baseCd, baseGcd = GetSpellBaseCooldown(spellID)
+  print(PREFIX, "Base CD  :", baseCd and (baseCd / 1000) or "nil",
+    "| Base GCD:", baseGcd and (baseGcd / 1000) or "nil")
+
+  local usable, insufficientPower = C_Spell.IsSpellUsable(spellID)
+  print(PREFIX, "Usable   :", tostring(usable), "| InsufficientPower:", tostring(insufficientPower))
+
+  local inRange = C_Spell.IsSpellInRange(spellID)
+  print(PREFIX, "InRange  :", tostring(inRange))
+
+  print(PREFIX, "Known    :", tostring(C_SpellBook.IsSpellKnown(spellID)))
+
+  local classRules = Internal.GetClassRules and Internal.GetClassRules()
+  if classRules and classRules[spellID] then
+    local rule = classRules[spellID]
+    local s = rule.settings or {}
+    print(PREFIX, "In Rules : yes | enabled:", tostring(s.enabled ~= false),
+      "| priority:", tostring(s.priority or 0))
+  else
+    print(PREFIX, "In Rules : no")
+  end
+
+  local activeIcon = State.activeIcons[spellID]
+  print(PREFIX, "Active   :", activeIcon and "yes" or "no")
+end
+
+----------------------------------------------------
+-- /cdc debug pool
+----------------------------------------------------
+function Debug:DumpPool()
+  print(PREFIX, "=== Icon Pool ===")
+  print(PREFIX, "Available  :", #State.iconPool)
+  print(PREFIX, "Active     :", #State.iconsByPriority)
+  print(PREFIX, "Next ID    :", State.nextIconID)
+  print(PREFIX, "Allocated  :", State.nextIconID - 1)
+  print(PREFIX, "Pool size  :", CooldownCursorDB.global.iconPoolSize or "?")
+end
+
+----------------------------------------------------
+-- /cdc debug log  (show the event ring buffer)
+----------------------------------------------------
+function Debug:DumpLog()
+  local filterCount = CountTable(eventFilter)
+  local header = "=== Event Log (" .. #eventLog .. "/" .. MAX_EVENT_LOG .. ")"
+  if filterCount == 1 then
+    header = header .. " [filter: " .. next(eventFilter) .. "]"
+  elseif filterCount > 1 then
+    header = header .. " [" .. filterCount .. " filters]"
+  end
+  print(PREFIX, header .. " ===")
+  if #eventLog == 0 then
+    print(PREFIX, "(empty — debug must be on when events fire)")
+    return
+  end
+  local now = GetTime()
+  for i, entry in ipairs(eventLog) do
+    local ago = string.format("%.2fs ago", now - entry.time)
+    local args = ""
+    for j = 1, math.min(3, #entry.args) do
+      args = args .. " " .. tostring(entry.args[j])
+    end
+    print(PREFIX, string.format("[%2d] %-42s (%s)%s", i, entry.event, ago, args))
+  end
+end
+
+----------------------------------------------------
+-- /cdc debug cache
+----------------------------------------------------
+function Debug:DumpCache()
+  print(PREFIX, "=== Spell Cache ===")
+
+  -- Spellbook cache (scanned from C_SpellBook)
+  local cacheInfo = addonTable.Spells:GetCacheInfo()
+  if cacheInfo.valid then
+    print(PREFIX, string.format("spellBookCache : %d spells | age: %.1fs / %ds TTL",
+      cacheInfo.size, cacheInfo.age, cacheInfo.expires))
+  elseif cacheInfo.size > 0 then
+    print(PREFIX, string.format("spellBookCache : %d spells | EXPIRED (age: %.1fs)",
+      cacheInfo.size, cacheInfo.age or 0))
+  else
+    print(PREFIX, "spellBookCache : empty (not yet scanned this session)")
+  end
+
+  -- knownSpellCache (per-session, wiped on spec change)
+  local total = CountTable(State.knownSpellCache)
+  print(PREFIX, "knownSpellCache:", total, "entries")
+  if total == 0 then return end
+
+  print(PREFIX, "--- knownSpellCache (first 20) ---")
+  local count = 0
+  for spellID, known in pairs(State.knownSpellCache) do
+    count = count + 1
+    if count > 20 then break end
+    local spellInfo = C_Spell.GetSpellInfo(spellID)
+    local name = spellInfo and spellInfo.name or "Unknown"
+    print(PREFIX, string.format("  [%d] %-24s known:%s", spellID, name, tostring(known)))
+  end
+  if total > 20 then
+    print(PREFIX, "  ... and", total - 20, "more")
+  end
+end
+
+----------------------------------------------------
+-- Export
+----------------------------------------------------
+Internal.DebugLog = DebugLog
+Internal.LogEvent = LogEvent
+
+addonTable.Modules.Debug = Debug

--- a/Modules/Spells.lua
+++ b/Modules/Spells.lua
@@ -248,6 +248,19 @@ function Spells:InvalidateSpellBookCache()
   spellBookCacheTime = 0
 end
 
+--- Get metadata about the spellbook cache state (for debug inspection)
+-- @return table - { size, age, expires, valid }
+function Spells:GetCacheInfo()
+  local now = GetTime()
+  local age = spellBookCacheTime > 0 and (now - spellBookCacheTime) or nil
+  return {
+    size    = spellBookCache and #spellBookCache or 0,
+    age     = age,
+    expires = CACHE_DURATION,
+    valid   = spellBookCache ~= nil and age ~= nil and age < CACHE_DURATION,
+  }
+end
+
 --- Get the SpellBookItemType name for a given enum value
 -- @param enumValue number - Enum.SpellBookItemType value
 -- @return string - Human readable name

--- a/Slash.lua
+++ b/Slash.lua
@@ -59,6 +59,7 @@ local function Help()
  /cdcursor help                     - Show this help message
  /cdcursor reset                    - Reset all settings to default
  /cdcursor status                   - Show current settings
+ /cdcursor debug                    - Toggle debug mode (subcommands: state|icons|rules|spell|pool|events|log|cache|filter)
 ]])
 end
 
@@ -530,6 +531,34 @@ function CooldownCursor:SerializeSettings()
   end
 
   return table.concat(parts, ";")
+end
+
+handlers.debug = function(arg1, arg2)
+  if not arg1 or arg1 == "" then
+    CooldownCursor:Toggle()
+    return
+  end
+  if arg1 == "state" then
+    CooldownCursor:DumpState()
+  elseif arg1 == "icons" then
+    CooldownCursor:DumpIcons()
+  elseif arg1 == "rules" then
+    CooldownCursor:DumpRules()
+  elseif arg1 == "spell" then
+    CooldownCursor:DumpSpell(arg2)
+  elseif arg1 == "pool" then
+    CooldownCursor:DumpPool()
+  elseif arg1 == "events" then
+    CooldownCursor:ToggleEvents()
+  elseif arg1 == "log" then
+    CooldownCursor:DumpLog()
+  elseif arg1 == "cache" then
+    CooldownCursor:DumpCache()
+  elseif arg1 == "filter" then
+    CooldownCursor:ToggleFilter(arg2)
+  else
+    Print("debug subcommands: state | icons | rules | spell <id> | pool | events | log | cache | filter")
+  end
 end
 
 handlers.status = function()

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,353 @@
+# CooldownCursor — Debugging Guide
+
+This guide covers the built-in debug tools added in the `Modules/Debug.lua` module.
+All debug output is printed to the in-game chat window with an orange `[CC Debug]` prefix.
+
+---
+
+## Enabling Debug Mode
+
+Debug mode is toggled with the slash command:
+
+```
+/cdc debug
+```
+
+- **ON** — all `Internal.DebugLog()` calls become active; events start recording to the buffer
+- **OFF** — all output stops; event buffer stops recording
+
+The flag is stored in `CooldownCursorDB.global.debugMode` and persists across sessions.
+Turn it off when not actively developing to avoid chat spam.
+
+### Event Logging (separate toggle)
+
+Event printing to chat can be noisy. Toggle it independently with:
+
+```
+/cdc debug events
+```
+
+- **ON** — events print to chat as they fire (default when debug mode is first enabled)
+- **OFF** — events are still recorded to the buffer silently; use `/cdc debug log` to inspect them
+
+The flag is stored in `CooldownCursorDB.global.debugLogEvents`. Turning events off lets you
+leave debug mode on for `DebugLog()` output without chat being flooded by every game event.
+
+---
+
+## Slash Commands
+
+All debug subcommands follow the pattern `/cdc debug <subcommand>`.
+
+| Command | Description |
+|---|---|
+| `/cdc debug` | Toggle debug mode on / off |
+| `/cdc debug state` | Dump current addon state |
+| `/cdc debug icons` | Dump all active icon frames |
+| `/cdc debug rules` | Dump spell rules for your current class/spec |
+| `/cdc debug spell <id>` | Full spell info lookup by spell ID |
+| `/cdc debug pool` | Icon pool statistics |
+| `/cdc debug events` | Toggle event printing on / off (events still recorded to buffer) |
+| `/cdc debug log` | Show the last 50 events in the buffer |
+| `/cdc debug cache` | Dump spell cache state (spellbook cache + knownSpellCache) |
+| `/cdc debug filter` | Show active event filter |
+| `/cdc debug filter <EVENT>` | Toggle an event name in/out of the filter |
+| `/cdc debug filter clear` | Clear all filters (record all events again) |
+
+---
+
+## Subcommand Reference
+
+### `state` — Addon State
+
+Prints a snapshot of the key runtime values from `addonTable.State`:
+
+```
+inCombat          : true/false
+previewActive     : true/false
+optionsOpen       : true/false
+playerClass       : WARRIOR / MAGE / etc.
+activeIcons       : N (icons currently displayed)
+iconPool          : N available, N allocated
+activeProcSpells  : N
+procCapableSpells : N
+knownSpellCache   : N entries
+cachedUIScale     : 1.0
+cachedScreen      : 2560 x 1440
+cachedIconSize    : 48
+cachedAnchor      : TOPRIGHT
+positionMode      : CURSOR / SCREEN
+showBehavior      : 0 / 1 / 2
+showWhen          : 0 / 1 / 2
+```
+
+**When to use:** Any time behaviour seems wrong — check `inCombat`, `showWhen`,
+`showBehavior`, and `positionMode` first.
+
+---
+
+### `icons` — Active Icons
+
+Lists every icon currently tracked in `State.iconsByPriority`:
+
+```
+[1] 12345  Frostbolt              prio:5  proc:false  procOnly:false  charges:false  shown  alpha:1.00  on-cd
+[2] 11426  Ice Barrier            prio:3  proc:false  procOnly:false  charges:false  hidden alpha:0.00  off-cd
+```
+
+**Columns:**
+- `[N]` — sort position (highest priority first by default)
+- Spell ID and name
+- `prio` — configured priority from spell rules
+- `proc` — whether `procActive` is set on this icon
+- `procOnly` — icon was created solely for a proc glow (no base cooldown)
+- `charges` — whether this spell has charges
+- `shown/hidden` — frame visibility
+- `alpha` — current frame alpha (0.00 = invisible, 1.00 = fully visible)
+- `on-cd / off-cd` — whether the cooldown swipe frame is active
+
+**When to use:** Icons appearing or disappearing unexpectedly, alpha/visibility issues,
+proc state not clearing correctly.
+
+---
+
+### `rules` — Spell Rules
+
+Lists all spell rules configured for your current class and spec:
+
+```
+[12345] Frostbolt               on  | prio:5  | cd:3.0s  | charges:false | active
+[11426] Ice Barrier             on  | prio:3  | cd:25.0s | charges:false | inactive
+[55342] Mirror Image            off | prio:0  | cd:120.0s| charges:false | inactive
+```
+
+**When to use:** A spell isn't showing — check it appears here and is `on`. If it's
+missing entirely, you need to add it via the Options UI or `/cdc` commands. If it shows
+`inactive`, the addon isn't tracking it yet (hasn't been cast this session).
+
+---
+
+### `spell <id>` — Spell Info Lookup
+
+Queries the full WoW API for a single spell ID and prints everything the addon uses to
+make decisions about it:
+
+```
+/cdc debug spell 12345
+```
+
+Output:
+```
+[CC Debug] === Spell 12345 (Frostbolt) ===
+[CC Debug] Icon ID   : 135846
+[CC Debug] CastTime  : 2.0 sec
+[CC Debug] Range     : 0 - 40
+[CC Debug] Cooldown  : start: 0  duration: 0  enabled: true
+[CC Debug] CD Dur    : nil (not on cooldown)
+[CC Debug] Charges   : none
+[CC Debug] Base CD   : 0  Base GCD: 1.5
+[CC Debug] Usable    : true  InsufficientPower: false
+[CC Debug] InRange   : nil
+[CC Debug] Known     : true
+[CC Debug] In Rules  : yes | enabled: true | priority: 5
+[CC Debug] Active    : false
+```
+
+**Key fields:**
+
+| Field | What it means |
+|---|---|
+| `CD Dur` | Return value of `C_Spell.GetSpellCooldownDuration()` — `nil` means the spell is not on cooldown right now. This is what the addon uses to decide whether to show an icon. |
+| `Base CD` | Base cooldown in seconds from `GetSpellBaseCooldown()`. GCD-only spells show `0` here. |
+| `InRange` | `nil` = range not applicable, `true` = in range, `false` = out of range. Out-of-range spells are suppressed unless `showBehavior` is `OFF_COOLDOWN`. |
+| `Known` | Whether your character currently knows this spell. Unknown spells are skipped by the cache. |
+| `In Rules` | Whether this spell has an entry in your class spell rules and whether it is enabled. |
+
+**When to use:** A specific spell never shows an icon. Walk through the output — if
+`Known` is false, `In Rules` is no/disabled, or `CD Dur` is nil after casting, you've
+found the reason.
+
+---
+
+### `events` — Toggle Event Printing
+
+```
+/cdc debug events
+```
+
+Toggles whether events are printed to chat as they fire. Events are **always recorded** to
+the ring buffer while debug mode is on — this toggle only controls the chat output.
+
+Use this to silence the event flood while still being able to call `/cdc debug log` on demand.
+
+---
+
+### `log` — Show Event Buffer
+
+Shows the last 50 events received by the `OnEvent` dispatcher, most recent at the bottom:
+
+```
+[ 1] ADDON_LOADED                               (2.34s ago) CooldownCursor
+[ 2] PLAYER_ENTERING_WORLD                      (2.30s ago)
+[ 3] SPELL_UPDATE_USABLE                        (1.12s ago)
+[ 4] UNIT_SPELLCAST_SUCCEEDED                   (0.45s ago) player  12345
+[ 5] SPELL_UPDATE_COOLDOWN                      (0.45s ago) 12345
+```
+
+> **Note:** The buffer only records events that fire **while debug mode is on**.
+> If the buffer is empty after enabling debug, cast a spell or change zones to generate events.
+> Event printing does **not** need to be on for the buffer to fill.
+
+**When to use:** Verify that expected events are firing. If `SPELL_UPDATE_COOLDOWN`
+never appears after casting, the event is not reaching the dispatcher.
+
+---
+
+### `cache` — Spell Cache State
+
+```
+/cdc debug cache
+```
+
+Output:
+
+```
+[CC Debug] === Spell Cache ===
+[CC Debug] spellBookCache : 142 spells | age: 3.2s / 60s TTL
+[CC Debug] knownSpellCache: 8 entries
+[CC Debug] --- knownSpellCache (first 20) ---
+[CC Debug]   [12345] Frostbolt               known:true
+[CC Debug]   [11426] Ice Barrier             known:true
+```
+
+**Fields:**
+
+| Field | What it means |
+|---|---|
+| `spellBookCache` | Result of the last `C_SpellBook` full scan. Shows entry count, how old the scan is, and whether it's still within the 60s TTL. If `EXPIRED`, the next call to `GetAllSpellBookSpells` will trigger a fresh scan. |
+| `knownSpellCache` | Per-session cache of `C_SpellBook.IsSpellKnown()` results, keyed by spell ID. Wiped on `PLAYER_SPECIALIZATION_CHANGED`. |
+
+**When to use:** A spell appears in rules but isn't showing — check if it's `known:true` in
+the knownSpellCache. If the spellbook cache is stale or empty, the addon may not have
+registered the spell yet.
+
+---
+
+### `pool` — Icon Pool Stats
+
+```
+[CC Debug] === Icon Pool ===
+[CC Debug] Available  : 8
+[CC Debug] Active     : 2
+[CC Debug] Next ID    : 11
+[CC Debug] Allocated  : 10
+[CC Debug] Pool size  : 10
+```
+
+**When to use:** Investigating frame leaks or pool exhaustion. If `Allocated` keeps
+growing well beyond `Pool size + Active`, frames are not returning to the pool correctly
+(check `ReturnIconToPool` in `Core.lua`).
+
+---
+
+### `events` — Toggle Event Printing (duplicate reference)
+
+See the [Events section](#events--toggle-event-printing) at the top of this reference, or the
+[Log section](#log--show-event-buffer) for viewing the recorded buffer.
+
+**Quick reminder:**
+
+- `/cdc debug events` — toggles whether events print to chat
+- `/cdc debug log` — shows the last 50 recorded events regardless of the print toggle
+
+---
+
+### `filter` — Event Filter
+
+Restricts the event log to only specific events. The filter is **in-memory** — it resets
+on `/reload` or logout, so it won't affect production sessions.
+
+```text
+/cdc debug filter                            -- show active filter
+/cdc debug filter SPELL_UPDATE_COOLDOWN      -- add or remove one event
+/cdc debug filter UNIT_SPELLCAST_SUCCEEDED   -- toggle a second event
+/cdc debug filter clear                      -- clear all filters
+```
+
+With no filter set, all events are recorded (default). When one or more events are added,
+only those pass through — the rest are silently dropped before reaching the ring buffer.
+
+The active filter is shown in the `/cdc debug log` header:
+
+```text
+[CC Debug] === Event Log (3/50) [filter: SPELL_UPDATE_COOLDOWN] ===
+[CC Debug] === Event Log (7/50) [2 filters] ===
+```
+
+**When to use:** You know which event you're tracking and don't want the buffer filled
+with unrelated events. For example, when debugging charge recovery you might filter to
+`SPELL_UPDATE_CHARGES` only.
+
+---
+
+## `Internal.DebugLog` — Logging from Other Modules
+
+Any module can conditionally log to the debug output:
+
+```lua
+local DebugLog = Internal.DebugLog  -- already exported by Debug.lua
+
+-- Somewhere in your module:
+DebugLog("ShowSpellIcon called for spellID:", spellID, "duration:", durationObj)
+```
+
+`DebugLog` is a no-op when debug mode is off, so it is safe to leave calls in place
+during development. Remove them before releasing.
+
+---
+
+## Common Debugging Scenarios
+
+### "My spell never shows an icon"
+
+1. `/cdc debug rules` — is the spell listed and enabled?
+2. `/cdc debug spell <id>` — is it `Known`? Is `CD Dur` returning a value after casting?
+3. `/cdc debug events` — does `UNIT_SPELLCAST_SUCCEEDED` fire when you cast it?
+4. `/cdc debug state` — is `showWhen` or `showBehavior` suppressing it?
+
+### "Icons disappear immediately after appearing"
+
+1. `/cdc debug state` — check `showBehavior` (0 = ON_COOLDOWN removes icon when CD ends)
+2. `/cdc debug icons` — check `on-cd` column right after casting
+3. `/cdc debug spell <id>` — check `CD Dur` — a spell with no real cooldown will be removed immediately in ON_COOLDOWN mode
+
+### "Proc icon not showing / not hiding"
+
+1. `/cdc debug state` — confirm `activeProcSpells` count changes when the proc fires
+2. `/cdc debug icons` — check `proc` and `procOnly` columns
+3. `/cdc debug events` — look for `SPELL_ACTIVATION_OVERLAY_GLOW_SHOW` / `_HIDE` events
+4. Check Options UI — `showProcs` must be enabled
+
+### "Icon position is wrong after scaling the UI"
+
+1. `/cdc debug state` — check `cachedUIScale`, `cachedScreen`, `cachedAnchor`
+2. Trigger a refresh: change UI scale or run `/cdc debug state` again after
+   `UI_SCALE_CHANGED` or `DISPLAY_SIZE_CHANGED` fires
+3. `cachedAnchorOX / OY` are pre-computed in `RefreshCachedSettings` (Cursor.lua) —
+   if the anchor is unexpectedly flipping, the screen boundary calculations in
+   `UpdateCooldownIconFrame` are the place to look
+
+---
+
+## File Reference
+
+| File | Role |
+|---|---|
+| [Modules/Debug.lua](../Modules/Debug.lua) | All debug functions and event log |
+| [Init.lua](../Init.lua) | Event dispatcher — calls `Internal.LogEvent` on every event |
+| [Slash.lua](../Slash.lua) | `/cdc debug` command entry point |
+| [Core.lua](../Core.lua) | `addonTable.State` definition |
+| [Modules/Cooldown.lua](../Modules/Cooldown.lua) | `GetSpellRule`, `ApplyShowBehavior` |
+| [Modules/Icons.lua](../Modules/Icons.lua) | `ShowSpellIcon`, `RemoveIconForSpell`, pool management |
+| [Modules/Cursor.lua](../Modules/Cursor.lua) | `UpdateCooldownIconFrame`, `RefreshCachedSettings` |
+| [Modules/Anchor.lua](../Modules/Anchor.lua) | Screen anchor, `ApplyPositionMode` |


### PR DESCRIPTION
… cache on spec change

Cursor.lua duplicated the full screen anchor implementation (EnsureAnchorFrame, ApplyAnchorPosition, IsScreenMode, UpdateAnchorVisibility, ApplyScreenAnchors, ApplyPositionMode) that already lives in Anchor.lua. Since Anchor.lua loads after Cursor.lua, its exports silently overwrote the Cursor.lua ones, leaving the Cursor.lua versions unreachable. Remove the dead section and its now-unused imports (C, Internal, POSITION_MODE).

Also call InvalidateSpellBookCache() in PLAYER_SPECIALIZATION_CHANGED so the Spells module cache is force-expired on spec swap alongside State.knownSpellCache, preventing stale spellbook data for up to 60 seconds after a spec change.

Update .gitignore

refactor: Replace monolithic OnEvent handler with dispatch table in Init.lua

- Replace if/else event chain with an eventHandlers dispatch table for cleaner, per-event handler functions that are easy to add or remove
- Add IsGuarded() helper consolidating CheckShowWhenState/CheckMountedState calls that were duplicated inline across multiple event branches
- Extract ProcessSpellEvent() for the debounce + cooldown query logic
- Extract HandleSpellCastEvent() as a shared handler for all four spell cast/cooldown events, wired via a loop over SPELL_CAST_EVENTS
- Remove SPELL_UPDATE_USABLE from SPELL_EVENTS (dead code: it was caught earlier in the chain and never reached that block)
- Remove redundant durationObj nil-check and commented-out usable line from ProcessSpellEvent

refactor: Add debugging function and doc